### PR TITLE
Fix env exports and add service-patch for OpenClaw 3.2

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -276,20 +276,23 @@ create_openclaw_user() {
     systemctl start "user@${OPENCLAW_UID}.service"
     log_ok "Lingering enabled, systemd user session started"
 
-    # Ensure npm global bin and XDG_RUNTIME_DIR are set for interactive shells
-    # (sudo -u openclaw -i doesn't go through full PAM, so systemd user
-    # services need XDG_RUNTIME_DIR explicitly)
+    # Ensure npm global bin, XDG_RUNTIME_DIR, and DBUS_SESSION_BUS_ADDRESS
+    # are set for all shell types (login, interactive, and non-interactive).
+    # .profile is sourced by login shells; .bashrc by interactive shells.
+    local profile="${OPENCLAW_HOME}/.profile"
     local bashrc="${OPENCLAW_HOME}/.bashrc"
-    if ! grep -q '.npm-global/bin' "$bashrc" 2>/dev/null; then
-        echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$bashrc"
-    fi
-    if ! grep -q 'XDG_RUNTIME_DIR' "$bashrc" 2>/dev/null; then
-        echo 'export XDG_RUNTIME_DIR="/run/user/$(id -u)"' >> "$bashrc"
-    fi
-    if ! grep -q 'DBUS_SESSION_BUS_ADDRESS' "$bashrc" 2>/dev/null; then
-        echo 'export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"' >> "$bashrc"
-    fi
-    chown openclaw:openclaw "$bashrc"
+    for rc in "$profile" "$bashrc"; do
+        if ! grep -q '.npm-global/bin' "$rc" 2>/dev/null; then
+            echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$rc"
+        fi
+        if ! grep -q 'XDG_RUNTIME_DIR' "$rc" 2>/dev/null; then
+            echo 'export XDG_RUNTIME_DIR="/run/user/$(id -u)"' >> "$rc"
+        fi
+        if ! grep -q 'DBUS_SESSION_BUS_ADDRESS' "$rc" 2>/dev/null; then
+            echo 'export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"' >> "$rc"
+        fi
+        chown openclaw:openclaw "$rc"
+    done
 }
 
 # ── Install Node.js ────────────────────────────────────────

--- a/docs/index.html
+++ b/docs/index.html
@@ -815,7 +815,7 @@
 
     <section class="do-deploy" id="digitalocean">
         <h2 class="section-heading">Deploy to DigitalOcean</h2>
-        <p class="section-subtitle">Three steps take a bare Ubuntu 24.04 droplet from zero to a fully hardened, TLS-terminated, production-ready instance.</p>
+        <p class="section-subtitle">Four steps take a bare Ubuntu 24.04 droplet from zero to a fully hardened, TLS-terminated, production-ready instance.</p>
 
         <div class="do-banner">
             <h3>Two scripts. Zero to production.</h3>
@@ -873,6 +873,15 @@
             </div>
             <div class="do-step">
                 <div class="do-step-number">3</div>
+                <div>
+                    <div class="step-label">Still as openclaw user · Temporary fix for OpenClaw 3.2</div>
+                    <h3>Patch the service</h3>
+                    <p>OpenClaw 3.2 has a known installation issue with the systemd service and environment variables. Run this one-liner to fix it. This step will be removed once OpenClaw ships a fix.</p>
+                    <div class="step-command" onclick="copyCommand(this)" data-copy="curl -fsSL https://raw.githubusercontent.com/zenithventure/openclaw-agent-teams/main/service-patch.sh | bash"><span class="prompt">$ </span>curl -fsSL https://raw.githubusercontent.com/zenithventure/openclaw-agent-teams/main/service-patch.sh | bash<button class="copy-icon" aria-label="Copy to clipboard"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" /></svg></button></div>
+                </div>
+            </div>
+            <div class="do-step">
+                <div class="do-step-number">4</div>
                 <div>
                     <div class="step-label">Still as openclaw user</div>
                     <h3>Deploy your team</h3>

--- a/service-patch.sh
+++ b/service-patch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Run as openclaw user after curl -fsSL https://openclaw.ai/install.sh | bash
+
+# 1. Add session env vars permanently
+echo '' >> ~/.bashrc
+echo 'export XDG_RUNTIME_DIR=/run/user/$(id -u)' >> ~/.bashrc
+echo 'export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus' >> ~/.bashrc
+
+# Apply immediately
+export XDG_RUNTIME_DIR=/run/user/$(id -u)
+export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus
+
+# 2. Fix Telegram groupPolicy in openclaw.json
+CONFIG=~/.openclaw/openclaw.json
+if [ -f "$CONFIG" ]; then
+    sed -i 's/"groupPolicy": "allowlist"/"groupPolicy": "open"/' "$CONFIG"
+    echo "Patched groupPolicy to open in $CONFIG"
+else
+    echo "Warning: $CONFIG not found — skipping groupPolicy patch"
+fi
+
+# 3. Create systemd user dir and unit file manually
+#    (bypasses the chicken-and-egg bug in 'openclaw gateway install')
+mkdir -p ~/.config/systemd/user/
+
+cat > ~/.config/systemd/user/openclaw-gateway.service << 'EOF'
+[Unit]
+Description=OpenClaw Gateway
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/openclaw/.npm-global/bin/openclaw gateway start
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+
+# 4. Enable and start the stub service so the check passes
+systemctl --user daemon-reload
+systemctl --user enable openclaw-gateway.service
+systemctl --user start openclaw-gateway.service
+
+# 5. Now let openclaw rewrite the unit file properly with the correct token
+sleep 3
+openclaw gateway install --force
+
+echo ""
+echo "Done. Check status with:"
+echo "  systemctl --user status openclaw-gateway.service"
+echo "  journalctl --user -u openclaw-gateway.service -f"


### PR DESCRIPTION
## Summary
- Add env exports (`XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`) to `.profile` in `bootstrap.sh` so they're available in non-interactive shells (fixes systemd/dbus issues)
- Add `service-patch.sh` — a temporary workaround for OpenClaw 3.2's broken install script (fixes systemd unit creation, env vars, and Telegram groupPolicy)
- Update landing page with a new deploy step (3 of 4) documenting the service patch

> **Note:** `service-patch.sh` is temporary and should be removed once OpenClaw fixes their installer.

## Test plan
- [ ] Run `bootstrap.sh` on a fresh Ubuntu 24.04 droplet and verify `.profile` contains the env exports
- [ ] Run `service-patch.sh` as the openclaw user after `openclaw install` and verify the gateway service starts
- [ ] Verify landing page renders correctly with the new step 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)