### PR TITLE
Phase 2: inventory-driven Ansible team deploy

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,20 +1,21 @@
 # Ansible (optional)
 
-The shell scripts at the repo root (`bootstrap.sh`, `install-team.sh`, and each
-team's `setup.sh`) are the primary deployment path. The two playbooks here
-mirror the same flow for power users running against a fleet of droplets.
+The shell scripts at the repo root (`bootstrap.sh`, `install-team.sh`, and
+the team `setup.sh`s) are the primary deployment path. The two playbooks
+here mirror the same flow declaratively for fleets of hosts.
 
 If you're deploying a single droplet, **use the shell flow** — open
-[DO-SETUP.md](../DO-SETUP.md). If you're deploying many droplets, or you want
-declarative inventory, use these playbooks.
+[DO-SETUP.md](../DO-SETUP.md). If you're deploying many hosts, or you
+want declarative inventory + per-host overrides, use these playbooks.
 
 ---
 
 ## Requirements
 
-- Ansible 2.14+
-- A target inventory with SSH access as a sudo-capable user
-- Ubuntu 24.04 on the targets
+- Ansible 2.14+ with the `ansible.posix` collection installed
+  (`ansible-galaxy collection install ansible.posix`)
+- `rsync` on the control machine and on the targets
+- Targets running Ubuntu 24.04 with SSH access as a sudo-capable user
 
 ---
 
@@ -22,13 +23,13 @@ declarative inventory, use these playbooks.
 
 ### `bootstrap.yml`
 
-Equivalent to `bootstrap.sh` — hardens the server, creates the `openclaw` and
-`claude` users, installs Node.js 22, and provisions Caddy with TLS.
+Equivalent to `bootstrap.sh` — hardens the server, creates the `openclaw`
+and `claude` users, installs Node.js 22, and provisions Caddy with TLS.
 
 Run as root (or via `become: true`):
 
 ```bash
-ansible-playbook -i hosts ansible/bootstrap.yml -l droplets \
+ansible-playbook -i ansible/inventory/production ansible/bootstrap.yml \
   -e admin_user=szewong \
   -e domain=teams.example.com
 ```
@@ -40,26 +41,54 @@ Variables:
 
 ### `openclaw-team.yml`
 
-Equivalent to running `install-team.sh --team <name>` as the `openclaw` user.
-Deploys agent workspaces, merges `openclaw.json`, and reloads the gateway.
+Inventory-driven team deploy. Reads `team`, `vision` / `vision_file`, and
+provider/channel secrets from your inventory (group_vars + host_vars),
+rsyncs the current repo to each target, and runs the generic deployer
+(`lib/deploy-team.sh`). Any team directory in the repo with
+`openclaw.json` + `agents/` is deployable — no allowlist.
 
 ```bash
-ansible-playbook -i hosts ansible/openclaw-team.yml -l droplets \
-  -e team=operator \
-  -e anthropic_api_key=sk-ant-…
+# Whole production fleet
+ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml
+
+# One host
+ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml \
+  -l example-host-1.example.com
+
+# Inline overrides for a one-off run
+ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml \
+  -e team=operator -e anthropic_api_key=sk-ant-...
 ```
 
-Variables:
-- `team` — required; one of `accountant`, `modernizer`, `operator`,
-  `product-builder`, `real-estate`, `recruiter`
-- `anthropic_api_key` — optional; sets `ANTHROPIC_API_KEY` in `~/.openclaw/.env`
+Variables (set in `host_vars/<host>.yml`, `group_vars/all.yml`, or `-e`):
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `team` | yes | Top-level directory in the repo with `openclaw.json` + `agents/` |
+| `vision` | no | Inline mission statement |
+| `vision_file` | no | Path (relative to repo root) to a markdown mission file — wins over `vision` |
+| `anthropic_api_key` | no\* | Sets `ANTHROPIC_API_KEY` in `~/.openclaw/.env`. \*Required for the gateway to work |
+| `telegram_bot_token`, `discord_bot_token`, `discord_user_id`, `slack_app_token`, `slack_bot_token` | no | Channel bindings — only set what each host uses |
+
+See [`inventory/README.md`](inventory/README.md) for the full layout,
+layering rules, and secrets guidance (Ansible Vault / `-e` injection).
+
+---
+
+## Iteration loop
+
+Edit team data in the repo → `ansible-playbook -i ansible/inventory/...
+ansible/openclaw-team.yml` → bots update on every targeted host. The
+playbook rsyncs the repo (excluding `.git`, `.env`, backups), re-runs
+the deployer (idempotent), then reloads the gateway. A no-change run is
+a near-no-op diff.
 
 ---
 
 ## What lives where
 
-| Need                     | Use                                                       |
-| ------------------------ | --------------------------------------------------------- |
-| One-droplet deploy       | `bootstrap.sh` + `install-team.sh` (the headline flow)    |
-| Fleet deploy             | These playbooks                                           |
-| BWS secrets / state backup | See [`../docs/advanced.md`](../docs/advanced.md) — both patterns ship in `~/git/DigitalOcean_setup/openclaw` |
+| Need                       | Use                                                                                  |
+| -------------------------- | ------------------------------------------------------------------------------------ |
+| One-host deploy            | `bootstrap.sh` + `install-team.sh` (the headline flow)                               |
+| Fleet deploy               | These playbooks + `ansible/inventory/`                                               |
+| BWS secrets / state backup | [`../docs/advanced.md`](../docs/advanced.md) — both patterns ship in `~/git/DigitalOcean_setup/openclaw` |

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -65,10 +65,16 @@ Variables (set in `host_vars/<host>.yml`, `group_vars/all.yml`, or `-e`):
 | Variable | Required | Notes |
 |----------|----------|-------|
 | `team` | yes | Top-level directory in the repo with `openclaw.json` + `agents/` |
-| `vision` | no | Inline mission statement |
-| `vision_file` | no | Path (relative to repo root) to a markdown mission file — wins over `vision` |
+| `vision` | no | Inline mission statement (generic/data teams only — see note) |
+| `vision_file` | no | Path (relative to repo root) to a markdown mission file — wins over `vision` (generic/data teams only) |
 | `anthropic_api_key` | no\* | Sets `ANTHROPIC_API_KEY` in `~/.openclaw/.env`. \*Required for the gateway to work |
 | `telegram_bot_token`, `discord_bot_token`, `discord_user_id`, `slack_app_token`, `slack_bot_token` | no | Channel bindings — only set what each host uses |
+
+> **`vision`/`vision_file` apply to generic (data) teams only.** A team with a
+> bespoke `setup.sh` that does not forward to `lib/deploy-team.sh` (currently
+> only `modernizer`) keeps its mission in a team-specific shared dir, not
+> `~/.openclaw/shared`. The playbook fails fast if you set `vision`/`vision_file`
+> for such a team — set the mission inside that team's own files instead.
 
 See [`inventory/README.md`](inventory/README.md) for the full layout,
 layering rules, and secrets guidance (Ansible Vault / `-e` injection).

--- a/ansible/inventory/README.md
+++ b/ansible/inventory/README.md
@@ -33,14 +33,21 @@ inventory/
 | Variable             | Typical location                 | Notes |
 |----------------------|----------------------------------|-------|
 | `team`               | `host_vars/<host>.yml` (or `group_vars/all.yml` for uniform fleets) | Name of a directory in the repo root with `openclaw.json` + `agents/`. |
-| `vision`             | `host_vars/<host>.yml`           | Inline mission statement string. |
-| `vision_file`        | `host_vars/<host>.yml`           | Path relative to repo root on the control machine; copied verbatim to `~/.openclaw/shared/VISION.md`. |
+| `vision`             | `host_vars/<host>.yml`           | Inline mission statement string. Generic/data teams only (see note). |
+| `vision_file`        | `host_vars/<host>.yml`           | Path relative to repo root on the control machine; copied verbatim to `~/.openclaw/shared/VISION.md`. Generic/data teams only. |
 | `anthropic_api_key`  | Ansible Vault or `-e` flag       | Required for the gateway to talk to Anthropic. |
 | `telegram_bot_token`, `discord_bot_token`, `discord_user_id`, `slack_app_token`, `slack_bot_token` | Vault / host_vars | Channel bindings. Only set the ones this host uses. |
 
 `vision_file` wins over `vision` when both are set. Both layer over the
 `shared/VISION.md` the team ships, and re-running the playbook is how you
 push edits to the fleet.
+
+> **`vision`/`vision_file` apply to generic (data) teams only.** A team with a
+> bespoke `setup.sh` that does not forward to `lib/deploy-team.sh` (currently
+> only `modernizer`) stores its mission in a team-specific shared dir, not
+> `~/.openclaw/shared`, and ignores `--vision`. The playbook asserts and fails
+> early if you set `vision`/`vision_file` for such a team — set the mission in
+> that team's own files instead.
 
 ---
 

--- a/ansible/inventory/README.md
+++ b/ansible/inventory/README.md
@@ -1,0 +1,101 @@
+# Ansible inventory
+
+Committed example inventory for the `openclaw-team.yml` playbook. Pick the
+environment you want to deploy and pass its directory with `-i`:
+
+```bash
+ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml
+ansible-playbook -i ansible/inventory/staging    ansible/openclaw-team.yml -l staging-host-1.example.com
+```
+
+The deployer is data-driven — the playbook reads `team`, `vision` /
+`vision_file`, and channel/API secrets from your inventory, then pushes
+the current repo state to each host and runs `lib/deploy-team.sh`.
+
+---
+
+## Layout
+
+```
+inventory/
+  production/
+    hosts.yml                 # host groups (replace placeholders with real hosts)
+    group_vars/
+      all.yml                 # defaults for every host in production
+    host_vars/
+      <hostname>.yml          # per-host overrides — vision, team, secrets
+  staging/                    # same shape as production
+    ...
+```
+
+### What goes where
+
+| Variable             | Typical location                 | Notes |
+|----------------------|----------------------------------|-------|
+| `team`               | `host_vars/<host>.yml` (or `group_vars/all.yml` for uniform fleets) | Name of a directory in the repo root with `openclaw.json` + `agents/`. |
+| `vision`             | `host_vars/<host>.yml`           | Inline mission statement string. |
+| `vision_file`        | `host_vars/<host>.yml`           | Path relative to repo root on the control machine; copied verbatim to `~/.openclaw/shared/VISION.md`. |
+| `anthropic_api_key`  | Ansible Vault or `-e` flag       | Required for the gateway to talk to Anthropic. |
+| `telegram_bot_token`, `discord_bot_token`, `discord_user_id`, `slack_app_token`, `slack_bot_token` | Vault / host_vars | Channel bindings. Only set the ones this host uses. |
+
+`vision_file` wins over `vision` when both are set. Both layer over the
+`shared/VISION.md` the team ships, and re-running the playbook is how you
+push edits to the fleet.
+
+---
+
+## Layering rules
+
+Standard Ansible precedence: `host_vars` > `group_vars/<group>` >
+`group_vars/all`. So a fleet-wide default in `group_vars/all.yml` is
+overridden by a group entry, which is overridden by a host entry.
+
+A common pattern:
+- Set `team: operator` in `group_vars/all.yml` if every host runs the same
+  team.
+- Set `vision` per host so each bot has its own mission.
+- Keep secrets out of `group_vars/all.yml` — use Vault, or pass `-e` at
+  invocation time.
+
+---
+
+## Secrets
+
+**Never commit plaintext API keys.** Two supported patterns:
+
+1. **Ansible Vault** (recommended for committed state):
+   ```bash
+   ansible-vault encrypt_string 'sk-ant-...' --name anthropic_api_key \
+     >> ansible/inventory/production/host_vars/example-host-1.example.com.yml
+   ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml --ask-vault-pass
+   ```
+
+2. **`-e` injection** (for one-off / CI runs):
+   ```bash
+   ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml \
+     -e anthropic_api_key="$ANTHROPIC_API_KEY"
+   ```
+
+For Bitwarden Secrets Manager (BWS) integration, see
+[`../../docs/advanced.md`](../../docs/advanced.md).
+
+---
+
+## Targeting subsets
+
+```bash
+# Whole production fleet
+ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml
+
+# One host
+ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml \
+  -l example-host-1.example.com
+
+# A subgroup (if you add `support_desks:` under `openclaw_hosts:`)
+ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml \
+  -l support_desks
+```
+
+Re-running against the same host(s) is how you roll out an edit. The
+playbook rsyncs the repo and re-runs the deployer — idempotent, so a
+no-change run is a near-no-op.

--- a/ansible/inventory/production/group_vars/all.yml
+++ b/ansible/inventory/production/group_vars/all.yml
@@ -1,0 +1,28 @@
+# Defaults for every host in production. Override per-host in
+# host_vars/<hostname>.yml.
+#
+# `team` is the directory name in the repo root (built-in or one you
+# authored). Any directory with openclaw.json + agents/ is deployable.
+
+# team: operator
+
+# Optional defaults shared across hosts. Almost everything below is more
+# naturally set per-host — defaults here are for "every host runs the
+# same team with the same channel" fleets.
+
+# vision: "Operate a small ops desk for ..."
+# vision_file: "operator/examples/visions/ops-desk.md"   # path relative to repo root
+
+# ── Secrets ───────────────────────────────────────────────────────────
+# Prefer Ansible Vault (`ansible-vault encrypt_string ...`) or `-e` /
+# environment injection. Never commit plaintext keys here.
+
+# anthropic_api_key: !vault |
+#   $ANSIBLE_VAULT;1.1;AES256
+#   ...
+
+# telegram_bot_token: ""
+# discord_bot_token: ""
+# discord_user_id: ""
+# slack_app_token: ""
+# slack_bot_token: ""

--- a/ansible/inventory/production/host_vars/example-host-1.example.com.yml
+++ b/ansible/inventory/production/host_vars/example-host-1.example.com.yml
@@ -1,0 +1,20 @@
+# Per-host overrides for example-host-1.example.com.
+#
+# Everything set here takes precedence over group_vars/all.yml. This is
+# the natural place for per-host vision, team, channel, and secrets.
+
+team: operator
+
+# Inline mission statement. For longer mission docs use `vision_file`
+# (path relative to the repo root on the control machine).
+vision: "Operate a small ops desk: triage support tickets, escalate billing issues, and post a daily summary."
+# vision_file: "operator/examples/visions/ops-desk.md"
+
+# Channel binding (uncomment what this host uses). Secret values should
+# come from Ansible Vault or `-e` flags — placeholders shown for shape.
+# anthropic_api_key: "sk-ant-..."
+# telegram_bot_token: "..."
+# discord_bot_token: "..."
+# discord_user_id: "..."
+# slack_app_token: "xapp-..."
+# slack_bot_token: "xoxb-..."

--- a/ansible/inventory/production/hosts.yml
+++ b/ansible/inventory/production/hosts.yml
@@ -1,0 +1,17 @@
+# Production inventory — example.
+#
+# Replace the example host below with your real targets. Each host should
+# already have been bootstrapped (ansible/bootstrap.yml or bootstrap.sh) so
+# the `openclaw` user and gateway are in place.
+#
+# The `openclaw_hosts` group is what `openclaw-team.yml` deploys to. Add
+# sub-groups (e.g. `support_desks`, `dev_pods`) under it if you want to
+# layer group_vars differently per cluster.
+
+all:
+  children:
+    openclaw_hosts:
+      hosts:
+        example-host-1.example.com:
+          # ansible_host: 203.0.113.10
+          # ansible_user: szewong

--- a/ansible/inventory/staging/group_vars/all.yml
+++ b/ansible/inventory/staging/group_vars/all.yml
@@ -1,0 +1,6 @@
+# Defaults for every host in staging. Same shape as
+# production/group_vars/all.yml; see that file for the full annotated set.
+
+# team: operator
+# vision: "Staging vision text..."
+# anthropic_api_key: !vault | ...

--- a/ansible/inventory/staging/hosts.yml
+++ b/ansible/inventory/staging/hosts.yml
@@ -1,0 +1,10 @@
+# Staging inventory — example. Mirror of production/hosts.yml for a
+# pre-prod environment.
+
+all:
+  children:
+    openclaw_hosts:
+      hosts:
+        staging-host-1.example.com:
+          # ansible_host: 198.51.100.10
+          # ansible_user: szewong

--- a/ansible/openclaw-team.yml
+++ b/ansible/openclaw-team.yml
@@ -1,58 +1,150 @@
 ---
-# Ansible port of install-team.sh + the team's setup.sh.
+# Inventory-driven team deploy.
 #
-# Deploys a team into ~/.openclaw on a host that already has OpenClaw
-# installed (run after `openclaw install.sh | bash` has been executed
-# as the openclaw user).
+# Reads team / vision / API keys from group_vars + host_vars, rsyncs the
+# current repo to each target, and runs the generic deployer
+# (lib/deploy-team.sh). A team is any top-level directory in the repo
+# with `openclaw.json` + `agents/` — there is no hardcoded allowlist.
 #
 # Usage:
-#   ansible-playbook -i hosts ansible/openclaw-team.yml -l droplets \
-#     -e team=operator -e anthropic_api_key=sk-ant-...
+#   ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml
+#   ansible-playbook -i ansible/inventory/staging    ansible/openclaw-team.yml \
+#     -l staging-host-1.example.com
 #
-# Variables:
-#   team               — required: accountant|modernizer|operator|product-builder|real-estate|recruiter
-#   anthropic_api_key  — optional; sets ANTHROPIC_API_KEY in ~/.openclaw/.env
-- hosts: all
+# Variables (set in host_vars/group_vars, or override with `-e`):
+#   team               REQUIRED — team directory name (built-in or yours)
+#   vision             optional — inline mission statement
+#   vision_file        optional — path (relative to repo root) to a markdown
+#                      mission file. Wins over `vision` when both set.
+#   anthropic_api_key  optional — sets ANTHROPIC_API_KEY in ~/.openclaw/.env
+#   telegram_bot_token, discord_bot_token, discord_user_id,
+#   slack_app_token, slack_bot_token — optional channel bindings
+- hosts: openclaw_hosts
   become: true
   become_user: openclaw
   gather_facts: true
 
   vars:
-    openclaw_dir: "/home/openclaw/.openclaw"
-    repo_root: "{{ playbook_dir }}/.."
-    valid_teams:
-      - accountant
-      - modernizer
-      - operator
-      - product-builder
-      - real-estate
-      - recruiter
+    openclaw_user: openclaw
+    openclaw_home: /home/openclaw
+    openclaw_dir: "{{ openclaw_home }}/.openclaw"
+    repo_local: "{{ playbook_dir }}/.."
+    repo_remote: "{{ openclaw_home }}/.openclaw-repo"
 
   pre_tasks:
-    - name: Ensure team is set and valid
+    - name: Require `team` to be set
       ansible.builtin.assert:
         that:
           - team is defined
-          - team in valid_teams
+          - team | length > 0
         fail_msg: >-
-          team must be one of: {{ valid_teams | join(', ') }}
+          `team` is required — set it in host_vars/group_vars (e.g.
+          host_vars/<host>.yml) or pass `-e team=<name>`.
+
+    - name: Stat team's required files on the controller
+      ansible.builtin.stat:
+        path: "{{ repo_local }}/{{ team }}/{{ item }}"
+      register: team_stat
+      delegate_to: localhost
+      become: false
+      loop:
+        - openclaw.json
+        - agents
+      loop_control:
+        label: "{{ team }}/{{ item }}"
+
+    - name: Fail if team is not structurally deployable
+      ansible.builtin.assert:
+        that:
+          - team_stat.results[0].stat.exists and (team_stat.results[0].stat.isreg | default(false))
+          - team_stat.results[1].stat.exists and (team_stat.results[1].stat.isdir | default(false))
+        fail_msg: >-
+          `{{ team }}` is not a deployable team — expected both
+          {{ repo_local }}/{{ team }}/openclaw.json (file) and
+          {{ repo_local }}/{{ team }}/agents/ (dir).
 
   tasks:
-    - name: Run the team's setup.sh (handles JSON merge, workspaces, skills)
-      ansible.builtin.shell: "bash {{ repo_root }}/{{ team }}/setup.sh"
+    # ── Push the current repo to the target ────────────────────────
+    - name: Ensure repo dir exists on target (owned by openclaw)
+      become_user: root
+      ansible.builtin.file:
+        path: "{{ repo_remote }}"
+        state: directory
+        owner: "{{ openclaw_user }}"
+        group: "{{ openclaw_user }}"
+        mode: '0755'
+
+    - name: Sync repo from controller to target
+      become: false
+      ansible.posix.synchronize:
+        src: "{{ repo_local }}/"
+        dest: "{{ repo_remote }}/"
+        delete: true
+        rsync_path: "sudo rsync"
+        rsync_opts:
+          - "--exclude=.git"
+          - "--exclude=node_modules"
+          - "--exclude=.env"
+          - "--exclude=*.backup.*"
+          - "--chown={{ openclaw_user }}:{{ openclaw_user }}"
+
+    - name: Ensure ~/.openclaw exists
+      ansible.builtin.file:
+        path: "{{ openclaw_dir }}"
+        state: directory
+        mode: '0700'
+
+    # ── Deploy the team (delegates to lib/deploy-team.sh) ──────────
+    - name: Deploy {{ team }}
+      ansible.builtin.shell: |
+        set -euo pipefail
+        TEAM_DIR="{{ repo_remote }}/{{ team }}"
+        EXTRA=()
+        {% if (vision is defined) and (vision | length > 0) and ((vision_file is not defined) or (vision_file | length == 0)) %}
+        EXTRA+=(--vision {{ vision | quote }})
+        {% endif %}
+        # Prefer the team's setup.sh when present — for built-in teams
+        # this is a thin shim over the generic deployer, but a team may
+        # ship bespoke logic (e.g. modernizer). Pure-data teams fall
+        # back to the deployer directly. Mirrors install-team.sh.
+        if [[ -f "${TEAM_DIR}/setup.sh" ]]; then
+          bash "${TEAM_DIR}/setup.sh" "${EXTRA[@]+"${EXTRA[@]}"}"
+        else
+          bash "{{ repo_remote }}/lib/deploy-team.sh" --team-dir "${TEAM_DIR}" "${EXTRA[@]+"${EXTRA[@]}"}"
+        fi
+      args:
+        executable: /bin/bash
       environment:
-        HOME: /home/openclaw
+        HOME: "{{ openclaw_home }}"
         OPENCLAW_DIR: "{{ openclaw_dir }}"
       changed_when: true
 
-    - name: Set ANTHROPIC_API_KEY in .env (if provided)
+    - name: Overwrite VISION.md from vision_file
+      ansible.builtin.copy:
+        src: "{{ repo_local }}/{{ vision_file }}"
+        dest: "{{ openclaw_dir }}/shared/VISION.md"
+        mode: '0644'
+      when: vision_file is defined and vision_file | length > 0
+
+    # ── Per-host secrets into ~/.openclaw/.env ─────────────────────
+    - name: Set provider / channel keys in .env
       ansible.builtin.lineinfile:
         path: "{{ openclaw_dir }}/.env"
-        regexp: '^#?\s*ANTHROPIC_API_KEY='
-        line: "ANTHROPIC_API_KEY={{ anthropic_api_key }}"
-        create: true
+        regexp: '^#?\s*{{ item.key }}='
+        line: "{{ item.key }}={{ item.value }}"
         mode: '0600'
-      when: anthropic_api_key is defined and anthropic_api_key | length > 0
+        create: true
+      loop:
+        - { key: ANTHROPIC_API_KEY,   value: "{{ anthropic_api_key   | default('') }}" }
+        - { key: TELEGRAM_BOT_TOKEN,  value: "{{ telegram_bot_token  | default('') }}" }
+        - { key: DISCORD_BOT_TOKEN,   value: "{{ discord_bot_token   | default('') }}" }
+        - { key: DISCORD_USER_ID,     value: "{{ discord_user_id     | default('') }}" }
+        - { key: SLACK_APP_TOKEN,     value: "{{ slack_app_token     | default('') }}" }
+        - { key: SLACK_BOT_TOKEN,     value: "{{ slack_bot_token     | default('') }}" }
+      when: item.value | length > 0
+      loop_control:
+        label: "{{ item.key }}"
+      no_log: true
 
     # ── OpenClaw 3.2 systemd workaround (matches install-team.sh::patch_service) ──
     - name: Patch Telegram groupPolicy to "open"
@@ -64,18 +156,18 @@
 
     - name: Ensure user systemd directory exists
       ansible.builtin.file:
-        path: /home/openclaw/.config/systemd/user
+        path: "{{ openclaw_home }}/.config/systemd/user"
         state: directory
         mode: '0755'
 
     - name: Stat the gateway unit file
       ansible.builtin.stat:
-        path: /home/openclaw/.config/systemd/user/openclaw-gateway.service
+        path: "{{ openclaw_home }}/.config/systemd/user/openclaw-gateway.service"
       register: gateway_unit
 
     - name: Write stub gateway unit (first install only)
       ansible.builtin.copy:
-        dest: /home/openclaw/.config/systemd/user/openclaw-gateway.service
+        dest: "{{ openclaw_home }}/.config/systemd/user/openclaw-gateway.service"
         mode: '0644'
         content: |
           [Unit]
@@ -84,7 +176,7 @@
 
           [Service]
           Type=simple
-          ExecStart=/home/openclaw/.npm-global/bin/openclaw gateway start
+          ExecStart={{ openclaw_home }}/.npm-global/bin/openclaw gateway start
           Restart=on-failure
           RestartSec=5
 
@@ -101,7 +193,7 @@
 
     - name: Let openclaw rewrite the unit file (first install only)
       ansible.builtin.shell: |
-        XDG_RUNTIME_DIR=/run/user/$(id -u) /home/openclaw/.npm-global/bin/openclaw gateway install --force
+        XDG_RUNTIME_DIR=/run/user/$(id -u) {{ openclaw_home }}/.npm-global/bin/openclaw gateway install --force
       when: not gateway_unit.stat.exists
       changed_when: true
       failed_when: false

--- a/ansible/openclaw-team.yml
+++ b/ansible/openclaw-team.yml
@@ -50,6 +50,7 @@
       loop:
         - openclaw.json
         - agents
+        - setup.sh
       loop_control:
         label: "{{ team }}/{{ item }}"
 
@@ -62,6 +63,32 @@
           `{{ team }}` is not a deployable team — expected both
           {{ repo_local }}/{{ team }}/openclaw.json (file) and
           {{ repo_local }}/{{ team }}/agents/ (dir).
+
+    # A team supports inventory-driven vision iff it deploys via the generic
+    # deployer — either it has no setup.sh (pure data) or its setup.sh is the
+    # thin shim that forwards to lib/deploy-team.sh. A bespoke setup.sh (e.g.
+    # modernizer) keeps its mission in a team-specific shared dir, not
+    # ~/.openclaw/shared, and ignores --vision — so `vision`/`vision_file`
+    # cannot be applied generically there.
+    - name: Detect whether the team supports inventory-driven vision
+      ansible.builtin.set_fact:
+        team_supports_vision: >-
+          {{ (not team_stat.results[2].stat.exists)
+             or ('deploy-team.sh' in lookup('file', repo_local ~ '/' ~ team ~ '/setup.sh')) }}
+
+    - name: Fail if vision is set for a team that can't apply it
+      ansible.builtin.assert:
+        that:
+          - team_supports_vision | bool
+        fail_msg: >-
+          `{{ team }}` ships a bespoke setup.sh that does not understand
+          inventory-driven `vision`/`vision_file` — its agents read a
+          team-specific shared dir, not {{ openclaw_dir }}/shared. Set the
+          mission inside the team's own files and drop `vision`/`vision_file`
+          for hosts running this team.
+      when: >-
+        (vision is defined and (vision | length > 0))
+        or (vision_file is defined and (vision_file | length > 0))
 
   tasks:
     # ── Push the current repo to the target ────────────────────────
@@ -119,12 +146,16 @@
         OPENCLAW_DIR: "{{ openclaw_dir }}"
       changed_when: true
 
+    # Only generic teams reach here with vision_file set (asserted above), so
+    # the generic deployer has already created {{ openclaw_dir }}/shared.
     - name: Overwrite VISION.md from vision_file
       ansible.builtin.copy:
         src: "{{ repo_local }}/{{ vision_file }}"
         dest: "{{ openclaw_dir }}/shared/VISION.md"
         mode: '0644'
-      when: vision_file is defined and vision_file | length > 0
+      when:
+        - vision_file is defined and vision_file | length > 0
+        - team_supports_vision | bool
 
     # ── Per-host secrets into ~/.openclaw/.env ─────────────────────
     - name: Set provider / channel keys in .env

--- a/docs/agent-as-a-service-plan.md
+++ b/docs/agent-as-a-service-plan.md
@@ -6,8 +6,8 @@ agent definition (1–N agents), and uses the deployer + **Ansible** to push and
 update that bot across one or more host VMs.
 
 **Status:** Phase 1 shipped (PR
-[#38](https://github.com/zenithventure/openclaw-agent-teams/pull/38), branch
-`claude/openclaw-agent-service-plan-8IYJw`). Phases 2–3 are open.
+[#38](https://github.com/zenithventure/openclaw-agent-teams/pull/38)). Phase 2
+shipped on branch `claude/openclaw-ansible-fleet-phase2`. Phase 3 is open.
 
 > Other sessions: read [`../CLAUDE.md`](../CLAUDE.md) first (the authoring
 > contract), then continue from the next unchecked phase below.
@@ -70,43 +70,41 @@ Validation done: all 8 teams deploy to temp dirs; idempotency, cross-team merge,
 
 ---
 
-## Phase 2 — Ansible fleet inventory + update loop  ⬜ TODO
+## Phase 2 — Ansible fleet inventory + update loop  ✅ DONE
 
-Goal: edit repo files → `ansible-playbook` → bots update on one or more VMs,
-with per-host config (vision, API key, channel) layered over group defaults.
+Shipped on `claude/openclaw-ansible-fleet-phase2`. Summary:
 
-Steps:
+- **`ansible/inventory/{production,staging}/`** committed example tree with
+  `hosts.yml`, `group_vars/all.yml`, `host_vars/<host>.yml`. Self-documenting
+  placeholders, plus `inventory/README.md` covering layering and secrets.
+- **`ansible/openclaw-team.yml`** rewritten:
+  - Dropped the `valid_teams` allowlist; pre_tasks now stat
+    `{{ repo_root }}/{{ team }}/openclaw.json` and `agents/` on the controller
+    and assert structurally.
+  - Reads `team`, `vision` / `vision_file`, `anthropic_api_key`, and channel
+    tokens (`telegram_bot_token`, `discord_bot_token`, `discord_user_id`,
+    `slack_app_token`, `slack_bot_token`) from group/host vars.
+  - **rsyncs the controller repo to the target** at
+    `/home/openclaw/.openclaw-repo` (via `sudo rsync` + `--chown`), excluding
+    `.git`, `.env`, backups, node_modules. This is what makes
+    edit-repo→re-run-playbook work without a manual clone.
+  - Deploys via the team's `setup.sh` when present (so `modernizer/` still
+    works), else `lib/deploy-team.sh --team-dir …` — mirroring
+    `install-team.sh`. `--vision` is passed inline when set.
+  - `vision_file` (path relative to repo root on the controller) overwrites
+    `~/.openclaw/shared/VISION.md` after deploy, taking precedence over
+    `vision` for longer mission docs.
+  - `.env` keys set via `lineinfile` with `no_log: true`.
+  - Existing service patch + reload steps preserved.
+- **`ansible/README.md`** rewritten around the inventory model — drops the
+  hardcoded team list, shows `-i ansible/inventory/production`, links to
+  `inventory/README.md`.
 
-1. **Add a committed inventory tree** under `ansible/inventory/`:
-   ```
-   ansible/inventory/
-     production/
-       hosts.yml                 # host groups
-       group_vars/all.yml        # defaults: team, model, channel
-       group_vars/<group>.yml    # per-group overrides
-       host_vars/<host>.yml      # per-host: vision/vision_file, api key ref, channel token
-     staging/ ...
-   ```
-   Ship example files (with placeholder hosts) so the structure is self-documenting.
-2. **Rework `ansible/openclaw-team.yml`:**
-   - Remove the hardcoded `valid_teams` assert (`ansible/openclaw-team.yml:23`);
-     validate structurally that `{{ repo_root }}/{{ team }}/openclaw.json` and
-     `agents/` exist.
-   - Read `team`, `vision` / `vision_file`, `anthropic_api_key`, and channel
-     tokens from group/host vars instead of only `-e team=`.
-   - Deploy via `bash {{ repo_root }}/lib/deploy-team.sh --team-dir
-     {{ repo_root }}/{{ team }}` (replaces the current `run the team's setup.sh`
-     shell task, but keep working for modernizer — prefer team `setup.sh` if
-     present, else the lib, mirroring `install-team.sh`).
-   - Write `VISION.md` from `vision_file`/`vision`; set `.env` keys; reload the
-     gateway (existing reload logic at `ansible/openclaw-team.yml:95` is fine).
-   - Keep it idempotent so re-runs = updates. Declarative agent files refresh;
-     `USER.md`/`VISION.md` seed-once unless explicitly overridden.
-3. **Per-host config layering:** `host_vars/<host>.yml` provides `vision` (inline)
-   or `vision_file` (committed, e.g. under the team's `examples/`), `team`,
-   `channel` + token, and an API-key reference.
-4. **Verify:** dry-run with `--check`; deploy to a throwaway host or container;
-   confirm `-l <host>` targets a subset and a second run is a no-op diff.
+Validation done: YAML parses for all new/changed playbook + inventory files;
+`lib/deploy-team.sh --team-dir _template` + `--vision …` smoke-tested in a
+tempdir; bash array idiom `${EXTRA[@]+"${EXTRA[@]}"}` verified under
+`set -euo pipefail`. Full `ansible-playbook --check` against a live target
+is still owed (no Ansible in the sandbox where this was authored).
 
 ## Phase 3 — secrets, docs, polish  ⬜ TODO
 


### PR DESCRIPTION
## Summary

- Reworks `ansible/openclaw-team.yml` to be **inventory-driven**: team, vision, and provider/channel secrets all come from `group_vars` + `host_vars` instead of `-e` overrides.
- The playbook now **rsyncs the controller's repo to each target** (excluding `.git`, `.env`, backups) before invoking the deployer, so the edit-locally → `ansible-playbook` → fleet-update loop works without a manual clone on each host.
- Drops the hardcoded `valid_teams` allowlist; `pre_tasks` stat the team's `openclaw.json` + `agents/` on the controller and fail with a clear message if either is missing. Prefers the team's `setup.sh` when present (modernizer still works), falls back to `lib/deploy-team.sh` for pure-data teams — mirrors `install-team.sh`.
- Adds an example **inventory tree** under `ansible/inventory/{production,staging}/` with annotated `hosts.yml`, `group_vars/all.yml`, `host_vars/<host>.yml`, and a `inventory/README.md` covering layering + secrets (Ansible Vault / `-e` injection).
- `vision_file` (path relative to repo root) overwrites `~/.openclaw/shared/VISION.md` after deploy; `--vision` is passed inline when only the inline string is set.
- `.env` keys (`ANTHROPIC_API_KEY`, telegram/discord/slack tokens) handled via `lineinfile` with `no_log: true`.
- Existing service patch + gateway reload steps preserved.
- Marks Phase 2 done in `docs/agent-as-a-service-plan.md`.

## Test plan

- [ ] `ansible-playbook --syntax-check -i ansible/inventory/production ansible/openclaw-team.yml`
- [ ] `ansible-playbook --check -i ansible/inventory/staging ansible/openclaw-team.yml -e team=operator -e vision='smoke test'` against a throwaway host
- [ ] Real deploy to a single bootstrapped host; verify `~/.openclaw/workspace-*`, merged `openclaw.json`, and `.env` keys land correctly, gateway reloads
- [ ] `-l <host>` targets a subset
- [ ] Second run is a near-no-op diff (rsync + lineinfile + deployer all idempotent)
- [ ] Confirm `--chown=openclaw:openclaw` via `sudo rsync` actually plants files as openclaw (i.e. ansible_user has passwordless sudo, as bootstrap.sh sets up)

## Validation already done

- YAML parses for all new/changed playbook + inventory files.
- `lib/deploy-team.sh --team-dir _template` + `--team-dir _template --vision "…"` smoke-tested in `OPENCLAW_DIR=$(mktemp -d)` — produces correct workspaces, merged JSON, and a rewritten VISION.md.
- Bash array idiom `"${EXTRA[@]+"${EXTRA[@]}"}"` verified to expand to zero args under `set -euo pipefail` (so passing no `--vision` flag stays clean).

Ansible isn't installed in the authoring sandbox, so `--syntax-check` / `--check` against a live host is still owed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)