### PR TITLE
Add team validator + CI to mechanize the authoring checklist (#41 item 1)

### DIFF
--- a/.github/workflows/validate-teams.yml
+++ b/.github/workflows/validate-teams.yml
@@ -1,0 +1,60 @@
+name: Validate teams
+
+# Mechanizes the CLAUDE.md authoring checklist + a deploy smoke test on every
+# push / PR, so a broken team or playbook is caught here instead of at deploy
+# time. See lib/validate-team.sh and issues #41 / #42.
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  validate-teams:
+    name: Team data + deploy smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Validate every team (structure, contract, canonical files, deploy)
+        run: bash lib/validate-team.sh --all --deploy
+
+      - name: Syntax-check shell scripts
+        run: |
+          set -e
+          shopt -s nullglob
+          for f in lib/*.sh */setup.sh bootstrap.sh install-team.sh; do
+            echo "bash -n $f"
+            bash -n "$f"
+          done
+
+  validate-ansible:
+    name: Ansible playbook syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # A recent ansible-core matters: the playbooks' `shell:` blocks are
+      # parsed by split_args at load time, which is where stray quotes /
+      # unbalanced jinja surface (see #42). Older cores were more lenient.
+      - name: Install Ansible + collections
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible-core
+          ansible-galaxy collection install ansible.posix community.general
+
+      - name: Syntax-check playbooks
+        run: |
+          set -e
+          ansible-playbook -i ansible/inventory/production ansible/bootstrap.yml --syntax-check
+          ansible-playbook -i ansible/inventory/production ansible/openclaw-team.yml --syntax-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,17 @@ and `VISION.md` are seeded once so live customizations survive re-deploys (use
 
 ## Authoring checklist
 
-Before considering a team done:
+Run the validator — it mechanizes everything below and CI runs it on every PR:
+
+```bash
+bash lib/validate-team.sh --team-dir <team-name>   # one team
+bash lib/validate-team.sh --all --deploy            # every team + deploy smoke test
+```
+
+Errors fail the build (invalid JSON, `agents/<id>` ⇄ `openclaw.json` id mismatch,
+missing required files, missing `> **Baseline:**` line, canonical files edited,
+`setup.sh` syntax). Warnings (e.g. a missing `## Core Workflow`/`## Safety`
+heading) are advisory. The manual checklist, for reference:
 
 - [ ] `openclaw.json` exists; every `agents/<id>/` has a matching `id` + `workspace`.
 - [ ] 1+ agents; each has IDENTITY, SOUL, AGENTS, HEARTBEAT, USER.

--- a/ansible/openclaw-team.yml
+++ b/ansible/openclaw-team.yml
@@ -164,7 +164,7 @@
         {% if (vision is defined) and (vision | length > 0) and ((vision_file is not defined) or (vision_file | length == 0)) %}
         EXTRA+=(--vision {{ vision | quote }})
         {% endif %}
-        # Prefer the team's setup.sh when present — for built-in teams
+        # Prefer the team setup.sh when present — for built-in teams
         # this is a thin shim over the generic deployer, but a team may
         # ship bespoke logic (e.g. modernizer). Pure-data teams fall
         # back to the deployer directly. Mirrors install-team.sh.

--- a/lib/validate-team.sh
+++ b/lib/validate-team.sh
@@ -85,13 +85,14 @@ validate_team() {
     [[ ${#agent_dirs[@]} -ge 1 ]] || err "no agent directories under agents/"
 
     # openclaw.json must be valid JSON; pull ids + workspaces.
-    local json_ids=() json_ws=""
+    local json_ids=() json_ws="" json_ok=false
     if [[ -f "${dir}/openclaw.json" ]]; then
         if [[ "$have_node" == true ]]; then
             if ! node -e "JSON.parse(require('fs').readFileSync('${dir}/openclaw.json','utf8'))" 2>/dev/null; then
                 err "openclaw.json is not valid JSON"
             else
                 ok "openclaw.json is valid JSON"
+                json_ok=true
                 while IFS= read -r id; do [[ -n "$id" ]] && json_ids+=("$id"); done \
                     < <(node -e "const c=require('${dir}/openclaw.json');(c.agents?.list||[]).forEach(a=>console.log(a.id))")
                 json_ws="$(node -e "const c=require('${dir}/openclaw.json');(c.agents?.list||[]).forEach(a=>console.log((a.id||'')+'\t'+(a.workspace||'')))")"
@@ -104,28 +105,33 @@ validate_team() {
     generic=true; is_generic "$dir" || generic=false
 
     # 2. agents/<id> <-> openclaw.json ids (generic teams only) --------------
-    if [[ "$generic" == true && ${#json_ids[@]} -gt 0 ]]; then
-        local only_dirs="" only_json="" d id found
-        for d in "${agent_dirs[@]}"; do
-            found=false; for id in "${json_ids[@]}"; do [[ "$d" == "$id" ]] && found=true; done
-            [[ "$found" == false ]] && only_dirs+="${d} "
-        done
-        for id in "${json_ids[@]}"; do
-            found=false; for d in "${agent_dirs[@]}"; do [[ "$d" == "$id" ]] && found=true; done
-            [[ "$found" == false ]] && only_json+="${id} "
-        done
-        if [[ -n "$only_dirs" || -n "$only_json" ]]; then
-            err "agents/<id> ⇄ openclaw.json mismatch — dirs only: [${only_dirs:-none}], json only: [${only_json:-none}]"
+    if [[ "$generic" == true && "$json_ok" == true ]]; then
+        if [[ ${#json_ids[@]} -eq 0 ]]; then
+            err "openclaw.json registers zero agents (agents.list is empty or missing) — a team must register at least one"
         else
-            ok "agents/ dirs and openclaw.json ids match (${#json_ids[@]} agents)"
-        fi
-        # Workspace convention.
-        if [[ -n "$json_ws" ]]; then
+            local only_dirs="" only_json="" d id found
+            for d in "${agent_dirs[@]}"; do
+                found=false; for id in "${json_ids[@]}"; do [[ "$d" == "$id" ]] && found=true; done
+                [[ "$found" == false ]] && only_dirs+="${d} "
+            done
+            for id in "${json_ids[@]}"; do
+                found=false; for d in "${agent_dirs[@]}"; do [[ "$d" == "$id" ]] && found=true; done
+                [[ "$found" == false ]] && only_json+="${id} "
+            done
+            if [[ -n "$only_dirs" || -n "$only_json" ]]; then
+                err "agents/<id> ⇄ openclaw.json mismatch — dirs only: [${only_dirs:-none}], json only: [${only_json:-none}]"
+            else
+                ok "agents/ dirs and openclaw.json ids match (${#json_ids[@]} agents)"
+            fi
+            # Workspace: must be present on every agent, and follow the convention.
             local wid wws
             while IFS=$'\t' read -r wid wws; do
                 [[ -z "$wid" ]] && continue
-                [[ "$wws" == "~/.openclaw/workspace-${wid}" ]] || \
+                if [[ -z "$wws" ]]; then
+                    err "agent '${wid}' has no 'workspace' in openclaw.json"
+                elif [[ "$wws" != "~/.openclaw/workspace-${wid}" ]]; then
                     warn "agent '${wid}' workspace is '${wws}' (convention: ~/.openclaw/workspace-${wid})"
+                fi
             done <<< "$json_ws"
         fi
     elif [[ "$generic" == false ]]; then

--- a/lib/validate-team.sh
+++ b/lib/validate-team.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+
+# ============================================================
+# OpenClaw Team Validator
+# ============================================================
+# Mechanizes the authoring checklist in CLAUDE.md so a broken
+# team is caught at commit/PR time instead of at deploy time.
+#
+# Checks (per team):
+#   - structural: openclaw.json (valid JSON) + agents/ + >=1 agent
+#   - agents/<id>/ dirs <-> openclaw.json ids match (generic teams)
+#   - workspace path convention ~/.openclaw/workspace-<id>
+#   - every agent has IDENTITY/SOUL/AGENTS/HEARTBEAT/USER.md
+#   - every AGENTS.md has the baseline line + Core Workflow + Safety
+#   - shared/ has VISION/STANDARDS/BOOTSTRAP/standup-log.md
+#   - STANDARDS.md and BOOTSTRAP.md are byte-identical to _template
+#   - setup.sh (if any) passes `bash -n`
+#   - optional (--deploy): temp-dir deploy smoke test
+#
+# A "bespoke" team (setup.sh that does NOT forward to
+# lib/deploy-team.sh, e.g. modernizer) is exempt from the
+# id<->dir and workspace-convention checks, mirroring the
+# Ansible playbook's `team_is_generic` gate.
+#
+# Usage:
+#   bash lib/validate-team.sh --team-dir <path>   # one team
+#   bash lib/validate-team.sh --all               # every team in the repo
+#   bash lib/validate-team.sh --all --deploy      # also smoke-test deploys
+#   bash lib/validate-team.sh --help
+#
+# Exit status: 0 if all validated teams pass, 1 otherwise.
+# ============================================================
+
+set -uo pipefail
+
+# ── Colors ─────────────────────────────────────────────────
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'; BOLD='\033[1m'; DIM='\033[2m'; NC='\033[0m'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEMPLATE_SHARED="${REPO_ROOT}/_template/shared"
+
+# ── Per-team check accounting ──────────────────────────────
+ERRORS=0
+WARNS=0
+err()  { echo -e "    ${RED}✗${NC} $1"; ERRORS=$((ERRORS+1)); }
+warn() { echo -e "    ${YELLOW}!${NC} $1"; WARNS=$((WARNS+1)); }
+ok()   { echo -e "    ${GREEN}✓${NC} $1"; }
+
+have_node=false
+command -v node &>/dev/null && have_node=true
+
+# ── Is this team deployed by the generic deployer? ─────────
+# Mirrors openclaw-team.yml: generic iff no setup.sh, or setup.sh
+# forwards to lib/deploy-team.sh. Bespoke teams (modernizer) are
+# exempt from id<->dir / workspace-convention checks.
+is_generic() {
+    local dir="$1"
+    [[ ! -f "${dir}/setup.sh" ]] && return 0
+    grep -q "deploy-team.sh" "${dir}/setup.sh" && return 0
+    return 1
+}
+
+# ── Validate one team ──────────────────────────────────────
+# Returns 0 if the team passed (no errors), 1 otherwise.
+validate_team() {
+    local dir name generic
+    dir="$(cd "$1" 2>/dev/null && pwd || true)"
+    if [[ -z "$dir" || ! -d "$dir" ]]; then
+        echo -e "  ${RED}✗ not a directory:${NC} $1"; return 1
+    fi
+    name="$(basename "$dir")"
+    ERRORS=0; WARNS=0
+    echo -e "\n${BOLD}▶ ${name}${NC} ${DIM}(${dir})${NC}"
+
+    # 1. Structural ----------------------------------------------------------
+    [[ -f "${dir}/openclaw.json" ]] || err "missing openclaw.json"
+    [[ -d "${dir}/agents" ]]        || err "missing agents/ directory"
+
+    # Collect agent dirs.
+    local agent_dirs=()
+    if [[ -d "${dir}/agents" ]]; then
+        while IFS= read -r d; do [[ -n "$d" ]] && agent_dirs+=("$(basename "$d")"); done \
+            < <(find "${dir}/agents" -mindepth 1 -maxdepth 1 -type d | sort)
+    fi
+    [[ ${#agent_dirs[@]} -ge 1 ]] || err "no agent directories under agents/"
+
+    # openclaw.json must be valid JSON; pull ids + workspaces.
+    local json_ids=() json_ws=""
+    if [[ -f "${dir}/openclaw.json" ]]; then
+        if [[ "$have_node" == true ]]; then
+            if ! node -e "JSON.parse(require('fs').readFileSync('${dir}/openclaw.json','utf8'))" 2>/dev/null; then
+                err "openclaw.json is not valid JSON"
+            else
+                ok "openclaw.json is valid JSON"
+                while IFS= read -r id; do [[ -n "$id" ]] && json_ids+=("$id"); done \
+                    < <(node -e "const c=require('${dir}/openclaw.json');(c.agents?.list||[]).forEach(a=>console.log(a.id))")
+                json_ws="$(node -e "const c=require('${dir}/openclaw.json');(c.agents?.list||[]).forEach(a=>console.log((a.id||'')+'\t'+(a.workspace||'')))")"
+            fi
+        else
+            warn "node not found — skipping JSON-level checks"
+        fi
+    fi
+
+    generic=true; is_generic "$dir" || generic=false
+
+    # 2. agents/<id> <-> openclaw.json ids (generic teams only) --------------
+    if [[ "$generic" == true && ${#json_ids[@]} -gt 0 ]]; then
+        local only_dirs="" only_json="" d id found
+        for d in "${agent_dirs[@]}"; do
+            found=false; for id in "${json_ids[@]}"; do [[ "$d" == "$id" ]] && found=true; done
+            [[ "$found" == false ]] && only_dirs+="${d} "
+        done
+        for id in "${json_ids[@]}"; do
+            found=false; for d in "${agent_dirs[@]}"; do [[ "$d" == "$id" ]] && found=true; done
+            [[ "$found" == false ]] && only_json+="${id} "
+        done
+        if [[ -n "$only_dirs" || -n "$only_json" ]]; then
+            err "agents/<id> ⇄ openclaw.json mismatch — dirs only: [${only_dirs:-none}], json only: [${only_json:-none}]"
+        else
+            ok "agents/ dirs and openclaw.json ids match (${#json_ids[@]} agents)"
+        fi
+        # Workspace convention.
+        if [[ -n "$json_ws" ]]; then
+            local wid wws
+            while IFS=$'\t' read -r wid wws; do
+                [[ -z "$wid" ]] && continue
+                [[ "$wws" == "~/.openclaw/workspace-${wid}" ]] || \
+                    warn "agent '${wid}' workspace is '${wws}' (convention: ~/.openclaw/workspace-${wid})"
+            done <<< "$json_ws"
+        fi
+    elif [[ "$generic" == false ]]; then
+        ok "bespoke team (setup.sh) — skipping id⇄dir + workspace convention checks"
+    fi
+
+    # 3. Per-agent required files + AGENTS.md contract -----------------------
+    local a f
+    for a in "${agent_dirs[@]}"; do
+        for f in IDENTITY.md SOUL.md AGENTS.md HEARTBEAT.md USER.md; do
+            [[ -f "${dir}/agents/${a}/${f}" ]] || err "agents/${a}/ missing ${f}"
+        done
+        local ag="${dir}/agents/${a}/AGENTS.md"
+        if [[ -f "$ag" ]]; then
+            # Baseline reference is load-bearing (every team has it) → error.
+            grep -q '^> \*\*Baseline:\*\*' "$ag" || err "agents/${a}/AGENTS.md missing the '> **Baseline:**' line"
+            grep -q 'STANDARDS.md' "$ag"          || err "agents/${a}/AGENTS.md baseline must reference STANDARDS.md"
+            # Section names are a recommendation; built-in teams (operator,
+            # modernizer) use equivalent headings, so warn rather than fail.
+            grep -q '^## Core Workflow' "$ag"      || warn "agents/${a}/AGENTS.md has no '## Core Workflow' (recommended by CLAUDE.md)"
+            grep -q '^## Safety' "$ag"             || warn "agents/${a}/AGENTS.md has no '## Safety' (recommended by CLAUDE.md)"
+        fi
+    done
+    [[ $ERRORS -eq 0 ]] && ok "required agent files present + baseline reference"
+
+    # 4. shared/ required files ----------------------------------------------
+    for f in VISION.md STANDARDS.md BOOTSTRAP.md standup-log.md; do
+        [[ -f "${dir}/shared/${f}" ]] || err "shared/ missing ${f}"
+    done
+
+    # 5. Canonical files unmodified (skip _template, which is the source) ----
+    if [[ "$name" != "_template" ]]; then
+        for f in STANDARDS.md BOOTSTRAP.md; do
+            if [[ -f "${dir}/shared/${f}" && -f "${TEMPLATE_SHARED}/${f}" ]]; then
+                if ! diff -q "${TEMPLATE_SHARED}/${f}" "${dir}/shared/${f}" >/dev/null 2>&1; then
+                    err "shared/${f} differs from _template (canonical — must be byte-identical)"
+                fi
+            fi
+        done
+        [[ $ERRORS -eq 0 ]] && ok "canonical shared files match _template"
+    fi
+
+    # 6. setup.sh syntax (if present) ----------------------------------------
+    if [[ -f "${dir}/setup.sh" ]]; then
+        if bash -n "${dir}/setup.sh" 2>/dev/null; then ok "setup.sh passes bash -n"
+        else err "setup.sh has a bash syntax error (bash -n)"; fi
+    fi
+
+    # 7. Optional deploy smoke test ------------------------------------------
+    if [[ "$DO_DEPLOY" == true ]]; then
+        local tmp; tmp="$(mktemp -d)"
+        if OPENCLAW_DIR="$tmp" bash "${REPO_ROOT}/lib/deploy-team.sh" --team-dir "$dir" >/dev/null 2>&1 \
+           && [[ -n "$(find "$tmp" -maxdepth 1 -name 'workspace-*' -print -quit)" ]]; then
+            ok "deploy smoke test (deployed to a temp dir)"
+        else
+            err "deploy smoke test failed"
+        fi
+        rm -rf "$tmp"
+    fi
+
+    # ── Verdict ──
+    if [[ $ERRORS -eq 0 ]]; then
+        echo -e "  ${GREEN}PASS${NC} ${name} ${DIM}(${WARNS} warning(s))${NC}"
+        return 0
+    fi
+    echo -e "  ${RED}FAIL${NC} ${name} ${DIM}(${ERRORS} error(s), ${WARNS} warning(s))${NC}"
+    return 1
+}
+
+# ── Discover teams (dir with openclaw.json + agents/) ──────
+discover_teams() {
+    local d
+    for d in "${REPO_ROOT}"/*/; do
+        [[ -f "${d}openclaw.json" && -d "${d}agents" ]] && echo "${d%/}"
+    done
+}
+
+# ── Args ───────────────────────────────────────────────────
+TEAM_DIR=""; DO_ALL=false; DO_DEPLOY=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --team-dir) shift; TEAM_DIR="${1:-}" ;;
+        --all)      DO_ALL=true ;;
+        --deploy)   DO_DEPLOY=true ;;
+        --help|-h)  sed -n '/^# Usage:/,/^# ====/p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) echo "Unknown flag: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [[ "$DO_DEPLOY" == true && "$have_node" != true ]]; then
+    echo -e "${YELLOW}!${NC} --deploy needs node for the JSON merge; smoke test may be limited." >&2
+fi
+
+# ── Run ────────────────────────────────────────────────────
+echo -e "${BOLD}OpenClaw team validator${NC}  ${DIM}(repo: ${REPO_ROOT})${NC}"
+declare -a TARGETS=()
+if [[ "$DO_ALL" == true ]]; then
+    while IFS= read -r t; do TARGETS+=("$t"); done < <(discover_teams)
+elif [[ -n "$TEAM_DIR" ]]; then
+    TARGETS=("$TEAM_DIR")
+else
+    echo "Provide --team-dir <path> or --all" >&2; exit 2
+fi
+
+[[ ${#TARGETS[@]} -eq 0 ]] && { echo "No teams found to validate." >&2; exit 2; }
+
+FAILED=()
+for t in "${TARGETS[@]}"; do
+    if ! validate_team "$t"; then FAILED+=("$(basename "$t")"); fi
+done
+
+echo ""
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+if [[ ${#FAILED[@]} -eq 0 ]]; then
+    echo -e "${GREEN}${BOLD}All ${#TARGETS[@]} team(s) passed.${NC}"
+    exit 0
+fi
+echo -e "${RED}${BOLD}${#FAILED[@]} of ${#TARGETS[@]} team(s) failed:${NC} ${FAILED[*]}"
+exit 1


### PR DESCRIPTION
## What

Implements **item #1 of #41** (authoring-time friction): a team validator that mechanizes the `CLAUDE.md` authoring checklist, plus CI to run it on every PR. This is the gate that was missing — the lesson from deploying `stock-picker` end-to-end was that bugs only surfaced at deploy time (#42).

## Changes

- **`lib/validate-team.sh`** — validates a team (or `--all`) against the authoring contract:
  - valid `openclaw.json`; `agents/<id>/` ⇄ `openclaw.json` id match (generic teams); workspace-path convention;
  - required per-agent files (IDENTITY/SOUL/AGENTS/HEARTBEAT/USER);
  - `AGENTS.md` carries the `> **Baseline:**` reference;
  - `shared/` has VISION/STANDARDS/BOOTSTRAP/standup-log;
  - **`STANDARDS.md` / `BOOTSTRAP.md` byte-identical to `_template`** (canonical);
  - `setup.sh` passes `bash -n`;
  - optional `--deploy`: temp-dir deploy smoke test via `lib/deploy-team.sh`.
- **`.github/workflows/validate-teams.yml`** — runs `validate-team.sh --all --deploy`, `bash -n` over shell scripts, and `ansible-playbook --syntax-check` on both playbooks (catches the `split_args`/apostrophe class of bug).
- **`ansible/openclaw-team.yml`** — re-applies the one-word apostrophe fix so this branch's own CI is green (same change also rides on the stock-picker/#42 branch; identical, so no merge conflict).
- **`CLAUDE.md`** — authoring checklist now points at the validator.

## Design decisions (grounded in what the validator found)

- **Errors vs warnings:** load-bearing, objective checks fail the build (JSON, id⇄dir, required files, baseline line, canonical files, `bash -n`). The `## Core Workflow` / `## Safety` section-name requirement is a **warning** — because `operator` and `modernizer` (built-in teams) use equivalent headings ("Prime Directive", "Rules", "What Not to Do"). This keeps the validator trusted/green on shipped teams while still nudging authors. **Note:** this is a real CLAUDE.md-contract-vs-reality drift; alternative is to reword those teams' headings.
- **Bespoke teams** (`modernizer`) are exempt from the id⇄dir / workspace-convention checks, mirroring the playbook's `team_is_generic` gate.

## Validation

- All 8 teams pass (`--all --deploy`), deploy smoke test included.
- Negative test: a team with bad JSON + missing baseline + tampered canonical file correctly **FAILs** with all 3 errors.
- Both playbooks pass `--syntax-check` locally after the apostrophe fix.

## Scope

Item #1 only. #41 items #2–#5 (de-dup canonical files, shared `USER.md`, playbook `set_fact` refactor, derived `openclaw.json`) are follow-ups — more invasive since they change the deployer and all teams.