### PR TITLE
Make openclaw.json optional — synthesize from agents/ (#41 item 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,14 +21,21 @@ need to write a shell script.
 
 ## What a team is
 
-A team is a top-level directory containing an `openclaw.json` and an `agents/`
-folder. It holds **1 to N agents**. A single-agent team is completely valid — the
-four-color DISC model used by the built-in teams is a useful *pattern*, not a
-requirement. Author as many agents as the job needs.
+A team is a top-level directory containing an `agents/` folder (and usually an
+`openclaw.json`). It holds **1 to N agents**. A single-agent team is completely
+valid — the four-color DISC model used by the built-in teams is a useful
+*pattern*, not a requirement. Author as many agents as the job needs.
+
+For a **uniform team** — one whose config is fully implied by its `agents/` dirs
+— you can omit `openclaw.json` entirely: the deployer synthesizes a default
+(each `agents/<id>/` → an agent with id `<id>`, a Title-Cased name, workspace
+`~/.openclaw/workspace-<id>`, subagents `["*"]`, agent-to-agent enabled for all
+ids). Ship an explicit `openclaw.json` only to customize names, tools, or
+permissions.
 
 ```
 <team-name>/
-  openclaw.json            # REQUIRED — agent definitions, tool perms, skills config
+  openclaw.json            # OPTIONAL — synthesized from agents/ if absent; ship to customize
   agents/                  # REQUIRED — one directory per agent
     <agent-id>/
       IDENTITY.md          # name, type, role (quick-reference card)
@@ -74,7 +81,10 @@ modernizer as a template; copy `_template/` or one of the four-color teams.
 
 ## openclaw.json conventions
 
-Minimum viable config (single agent):
+You only need this file to **customize** beyond the synthesized default (custom
+agent names, tool permissions, agent-to-agent allowlists, skills dirs). A
+uniform team can omit it. When you do ship one, this is the minimum viable
+config (single agent):
 
 ```json
 {
@@ -158,7 +168,8 @@ missing required files, missing `> **Baseline:**` line, canonical files edited,
 `setup.sh` syntax). Warnings (e.g. a missing `## Core Workflow`/`## Safety`
 heading) are advisory. The manual checklist, for reference:
 
-- [ ] `openclaw.json` exists; every `agents/<id>/` has a matching `id` + `workspace`.
+- [ ] `agents/` exists with 1+ agent dirs. `openclaw.json` is optional; if you
+      ship one, every `agents/<id>/` must have a matching `id` + `workspace`.
 - [ ] 1+ agents; each has IDENTITY, SOUL, AGENTS, HEARTBEAT, USER.
 - [ ] Every `AGENTS.md` starts with the `> **Baseline:**` line and has Core
       Workflow + Safety.

--- a/_template/README.md
+++ b/_template/README.md
@@ -13,7 +13,7 @@ A team holds **1 to N agents**. A single agent is completely valid; the four-col
 ```
 team-name/
   README.md                  # Team overview (for humans browsing the repo) — optional
-  openclaw.json              # REQUIRED — agent definitions, tool permissions, skill config
+  openclaw.json              # OPTIONAL — synthesized from agents/ if absent; ship it to customize names/tools/perms
   setup.sh                   # OPTIONAL — thin shim over lib/deploy-team.sh (built-in teams have one)
   env.template               # OPTIONAL — custom .env with extra provider/service keys
   agents/                    # REQUIRED — one directory per agent (1..N)
@@ -168,7 +168,7 @@ Before deploying a new team, verify:
 - [ ] **shared/VISION.md** — has all required sections (even if placeholder)
 - [ ] **shared/STANDARDS.md / BOOTSTRAP.md** — NOT vendored (the deployer supplies them from `_template`)
 - [ ] **shared/standup-log.md** — exists with header
-- [ ] **openclaw.json** — every agent defined with matching `id` and workspace path
+- [ ] **openclaw.json** — OPTIONAL (synthesized from `agents/` if absent); if shipped, every agent has a matching `id` + workspace path
 - [ ] **Validates** — `bash lib/validate-team.sh --team-dir <your-team> --deploy`
 - [ ] **README.md** — team-level README explaining purpose, agents, and example VISIONs
 

--- a/ansible/openclaw-team.yml
+++ b/ansible/openclaw-team.yml
@@ -57,12 +57,11 @@
     - name: Fail if team is not structurally deployable
       ansible.builtin.assert:
         that:
-          - team_stat.results[0].stat.exists and (team_stat.results[0].stat.isreg | default(false))
           - team_stat.results[1].stat.exists and (team_stat.results[1].stat.isdir | default(false))
         fail_msg: >-
-          `{{ team }}` is not a deployable team — expected both
-          {{ repo_local }}/{{ team }}/openclaw.json (file) and
-          {{ repo_local }}/{{ team }}/agents/ (dir).
+          `{{ team }}` is not a deployable team — expected
+          {{ repo_local }}/{{ team }}/agents/ (dir). openclaw.json is optional
+          (the deployer synthesizes one from agents/ when absent).
 
     # A team is "generic" iff it deploys via lib/deploy-team.sh — either it has
     # no setup.sh (pure data) or its setup.sh is the thin shim that forwards to
@@ -90,10 +89,12 @@
         (vision is defined and (vision | length > 0))
         or (vision_file is defined and (vision_file | length > 0))
 
-    # Structural sanity (generic teams only): the deployer maps
-    # agents/<id>/ ⇄ openclaw.json agent id. A dir without a matching id is
-    # never registered; an id without a dir registers an agent with no
-    # workspace files. Catch both on the controller before we touch any host.
+    # Structural sanity (generic teams that ship an openclaw.json): the deployer
+    # maps agents/<id>/ ⇄ openclaw.json agent id. A dir without a matching id is
+    # never registered; an id without a dir registers an agent with no workspace
+    # files. Catch both on the controller before we touch any host. Teams that
+    # omit openclaw.json get it synthesized from agents/ (ids = dir names), so
+    # there's nothing to cross-check.
     - name: List agent directories on the controller
       ansible.builtin.find:
         paths: "{{ repo_local }}/{{ team }}/agents"
@@ -122,7 +123,7 @@
         openclaw_agent_ids: >-
           {{ (lookup('file', repo_local ~ '/' ~ team ~ '/openclaw.json') | from_json).agents.list
              | map(attribute='id') | list }}
-      when: team_is_generic | bool
+      when: team_is_generic | bool and team_stat.results[0].stat.exists
 
   tasks:
     # ── Push the current repo to the target ────────────────────────

--- a/install-team.sh
+++ b/install-team.sh
@@ -154,7 +154,7 @@ clone_repo() {
 list_available_teams() {
     local d
     for d in "${CLONE_DIR}"/*/; do
-        if [[ -f "${d}openclaw.json" && -d "${d}agents" ]]; then
+        if [[ -d "${d}agents" ]]; then
             echo "    - $(basename "$d")"
         fi
     done
@@ -164,10 +164,11 @@ list_available_teams() {
 run_team_deploy() {
     local team_dir="${CLONE_DIR}/${TEAM}"
 
-    # Structural validation: a team is any dir with openclaw.json + agents/.
-    if [[ ! -f "${team_dir}/openclaw.json" || ! -d "${team_dir}/agents" ]]; then
+    # Structural validation: a team is any dir with agents/ (openclaw.json is
+    # optional — the deployer synthesizes one from agents/ when absent).
+    if [[ ! -d "${team_dir}/agents" ]]; then
         log_err "Not a deployable team: ${TEAM}"
-        echo "  (a team directory needs openclaw.json and agents/)"
+        echo "  (a team directory needs an agents/ dir)"
         echo ""
         echo "  Available teams:"
         list_available_teams

--- a/lib/deploy-team.sh
+++ b/lib/deploy-team.sh
@@ -80,14 +80,11 @@ if [[ -z "$TEAM_DIR" || ! -d "$TEAM_DIR" ]]; then
     log_err "Team directory not found"
     exit 1
 fi
-if [[ ! -f "${TEAM_DIR}/openclaw.json" ]]; then
-    log_err "Not a team directory (missing openclaw.json): ${TEAM_DIR}"
-    exit 1
-fi
 if [[ ! -d "${TEAM_DIR}/agents" ]]; then
     log_err "Not a team directory (missing agents/): ${TEAM_DIR}"
     exit 1
 fi
+# openclaw.json is optional — synthesized from agents/ below when absent.
 
 TEAM_NAME="$(basename "$TEAM_DIR")"
 OPENCLAW_DIR="${OPENCLAW_DIR:-$HOME/.openclaw}"
@@ -122,13 +119,46 @@ if [[ ${#AGENT_DIRS[@]} -eq 0 ]]; then
     exit 1
 fi
 
-# Agent ids (for JSON merge / removal) come from openclaw.json so
-# teams whose ids differ from their dir names still work.
 have_node=false
 command -v node &>/dev/null && have_node=true
 
+# openclaw.json is optional: a "uniform" team (config fully implied by its
+# agents/ dirs) can omit it and the deployer synthesizes a default — each
+# agents/<id>/ becomes an agent { id, name, workspace, subagents:["*"] }, with
+# agent-to-agent enabled for all ids and the standard skills dir. Ship an
+# explicit openclaw.json only for custom names, tools, or permissions.
+TMP_JSON_DIR=""
+cleanup_tmp() { [[ -n "$TMP_JSON_DIR" && -d "$TMP_JSON_DIR" ]] && rm -rf "$TMP_JSON_DIR"; return 0; }
+trap cleanup_tmp EXIT
+
+INCOMING_JSON="${TEAM_DIR}/openclaw.json"
+if [[ ! -f "$INCOMING_JSON" ]]; then
+    if [[ "$have_node" != true ]]; then
+        log_err "openclaw.json is missing and node is unavailable to synthesize one"
+        exit 1
+    fi
+    # Write to <tmpdir>/openclaw.json so require() resolves it by extension.
+    TMP_JSON_DIR="$(mktemp -d)"
+    INCOMING_JSON="${TMP_JSON_DIR}/openclaw.json"
+    local_ids_csv="$(printf '"%s",' "${AGENT_DIRS[@]}")"; local_ids_csv="[${local_ids_csv%,}]"
+    # name: strip a leading DISC color, split on -/_ , Title Case (red-strategist → "Strategist").
+    IDS_CSV="$local_ids_csv" node -e '
+const fs=require("fs");
+const ids=JSON.parse(process.env.IDS_CSV);
+const title=s=>s.replace(/^(red|yellow|green|blue)-/,"").split(/[-_]/).filter(Boolean)
+  .map(w=>w[0].toUpperCase()+w.slice(1)).join(" ")||s;
+const list=ids.map(id=>({id,name:title(id),workspace:"~/.openclaw/workspace-"+id,subagents:{allowAgents:["*"]}}));
+const cfg={agents:{defaults:{compaction:{mode:"safeguard"},maxConcurrent:4,subagents:{maxConcurrent:8}},list},
+  tools:{agentToAgent:{enabled:true,allow:ids}},skills:{load:{extraDirs:["~/.openclaw/skills"]}}};
+fs.writeFileSync(process.argv[1],JSON.stringify(cfg,null,2)+"\n");
+' "$INCOMING_JSON"
+    log_warn "openclaw.json synthesized from agents/ (${#AGENT_DIRS[@]} agents) — ship one to customize"
+fi
+
+# Agent ids (for JSON merge / removal) come from the config so teams whose ids
+# differ from their dir names still work.
 agent_ids_json() {
-    node -e "const c=require('${TEAM_DIR}/openclaw.json'); (c.agents?.list||[]).forEach(a=>console.log(a.id))"
+    node -e "const c=require('${INCOMING_JSON}'); (c.agents?.list||[]).forEach(a=>console.log(a.id))"
 }
 
 AGENT_IDS=()
@@ -240,7 +270,7 @@ create_directories() {
 deploy_config() {
     log_step "Deploying openclaw.json..."
     local config_file="${OPENCLAW_DIR}/openclaw.json"
-    local incoming="${TEAM_DIR}/openclaw.json"
+    local incoming="${INCOMING_JSON}"
 
     if [[ -f "${config_file}" ]]; then
         cp "${config_file}" "${config_file}.backup.$(date +%Y%m%d%H%M%S)"
@@ -445,7 +475,7 @@ print_summary() {
     echo -e "${BOLD}Team:${NC} ${TEAM_NAME}  (${#AGENT_DIRS[@]} agents, ${#SKILL_SRCS[@]} skills)"
     if [[ "$have_node" == true ]]; then
         echo -e "${BOLD}Agents:${NC}"
-        node -e "const c=require('${TEAM_DIR}/openclaw.json'); (c.agents?.list||[]).forEach(a=>console.log('  ● '+(a.name||a.id)+'  ('+a.id+')'))"
+        node -e "const c=require('${INCOMING_JSON}'); (c.agents?.list||[]).forEach(a=>console.log('  ● '+(a.name||a.id)+'  ('+a.id+')'))"
     fi
     echo ""
     echo -e "${BOLD}Directory:${NC} ${OPENCLAW_DIR}/"

--- a/lib/validate-team.sh
+++ b/lib/validate-team.sh
@@ -73,8 +73,9 @@ validate_team() {
     echo -e "\n${BOLD}▶ ${name}${NC} ${DIM}(${dir})${NC}"
 
     # 1. Structural ----------------------------------------------------------
-    [[ -f "${dir}/openclaw.json" ]] || err "missing openclaw.json"
-    [[ -d "${dir}/agents" ]]        || err "missing agents/ directory"
+    # agents/ is required; openclaw.json is optional (the deployer synthesizes
+    # one from agents/ for uniform teams).
+    [[ -d "${dir}/agents" ]] || err "missing agents/ directory"
 
     # Collect agent dirs.
     local agent_dirs=()
@@ -84,9 +85,12 @@ validate_team() {
     fi
     [[ ${#agent_dirs[@]} -ge 1 ]] || err "no agent directories under agents/"
 
-    # openclaw.json must be valid JSON; pull ids + workspaces.
-    local json_ids=() json_ws="" json_ok=false
+    # openclaw.json: if present, must be valid JSON; pull ids + workspaces. If
+    # absent, the deployer synthesizes it from agents/ (ids = dir names), so
+    # there's nothing to mismatch. has_json = file present; json_ok = parsed OK.
+    local json_ids=() json_ws="" has_json=false json_ok=false
     if [[ -f "${dir}/openclaw.json" ]]; then
+        has_json=true
         if [[ "$have_node" == true ]]; then
             if ! node -e "JSON.parse(require('fs').readFileSync('${dir}/openclaw.json','utf8'))" 2>/dev/null; then
                 err "openclaw.json is not valid JSON"
@@ -100,12 +104,15 @@ validate_team() {
         else
             warn "node not found — skipping JSON-level checks"
         fi
+    else
+        ok "openclaw.json omitted — deployer synthesizes it from agents/ (ids = dir names)"
+        json_ids=("${agent_dirs[@]}")
     fi
 
     generic=true; is_generic "$dir" || generic=false
 
-    # 2. agents/<id> <-> openclaw.json ids (generic teams only) --------------
-    if [[ "$generic" == true && "$json_ok" == true ]]; then
+    # 2. agents/<id> ⇄ openclaw.json ids (generic teams that ship a json) ----
+    if [[ "$generic" == true && "$has_json" == true && "$json_ok" == true ]]; then
         if [[ ${#json_ids[@]} -eq 0 ]]; then
             err "openclaw.json registers zero agents (agents.list is empty or missing) — a team must register at least one"
         else
@@ -227,7 +234,7 @@ validate_team() {
 discover_teams() {
     local d
     for d in "${REPO_ROOT}"/*/; do
-        [[ -f "${d}openclaw.json" && -d "${d}agents" ]] && echo "${d%/}"
+        [[ -d "${d}agents" ]] && echo "${d%/}"
     done
 }
 


### PR DESCRIPTION
## What

**Item #5 of #41.** Makes `openclaw.json` **optional**. For a "uniform" team — one whose config is fully implied by its `agents/` dirs — the deployer synthesizes a default, so you don't hand-write (and can't typo) the most error-prone file.

> 🔗 **Stacked on #45** (`feature/dedup-canonical-files`), which is stacked on #44. Merge order: #44 → #45 → this. I'll retarget bases as they land.

## How it works

Omit `openclaw.json`; the deployer builds one from `agents/<id>/`:
- each dir → `{ id: "<id>", name: <color-stripped Title Case>, workspace: "~/.openclaw/workspace-<id>", subagents: ["*"] }` (e.g. `red-lead` → name "Lead")
- `tools.agentToAgent.allow` = all ids; standard `skills.load.extraDirs`.

Ship an explicit `openclaw.json` only to customize names, tools, or permissions.

## Changes

- **`lib/deploy-team.sh`** — synthesize config from `agents/` when absent (written to a tmpdir as `openclaw.json` so `require()` resolves it), fed through the existing merge. Requires node; errors clearly without it.
- **`lib/validate-team.sh`** — `agents/` is the structural requirement; `openclaw.json` optional. Present → validated as before; absent → reported as synthesized (ids = dir names), id⇄dir check skipped (trivially satisfied). `discover_teams` keys on `agents/`.
- **`install-team.sh`** — discovery + structural check key on `agents/` only.
- **`ansible/openclaw-team.yml`** — structural assert requires `agents/`; the agents⇄ids cross-check runs only when a json is shipped.
- **`CLAUDE.md` + `_template/README.md`** — `openclaw.json` documented as optional.

## A bug the validator caught

The new tmp-cleanup `EXIT` trap returned non-zero when no synthesis happened, making `deploy-team.sh` exit 1 on success — which the validator's own **deploy smoke test** (added in #44) flagged immediately. Fixed (`return 0`). Nice confirmation the CI gate works.

## Validation

- All 8 built-in teams pass `validate-team.sh --all --deploy`.
- A team with **no `openclaw.json`** validates + deploys (config synthesized; names derived correctly).
- Idempotent re-deploy of a synthesized team doesn't duplicate agents.
- Both playbooks pass `--syntax-check`.