### PR TITLE
Harden bootstrap.yml: dash &> loop, admin .ssh dir, bash convention (#42 bucket A)

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -29,7 +29,9 @@
     # ── Phase 1: Hardening ───────────────────────────────────
     - name: Wait for any running apt/dpkg locks
       ansible.builtin.shell: |
-        while fuser /var/lib/dpkg/lock-frontend &>/dev/null 2>&1; do sleep 5; done
+        while fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do sleep 5; done
+      args:
+        executable: /bin/bash
       changed_when: false
 
     - name: Install system packages
@@ -66,6 +68,15 @@
         user: "{{ admin_user }}"
         key: "{{ ssh_key }}"
       when: ssh_key | length > 0
+
+    - name: Ensure admin user's .ssh dir exists (fallback copy target)
+      ansible.builtin.file:
+        path: "/home/{{ admin_user }}/.ssh"
+        state: directory
+        mode: '0700'
+        owner: "{{ admin_user }}"
+        group: "{{ admin_user }}"
+      when: ssh_key | length == 0
 
     - name: Copy root's authorized_keys to admin user (DO-injected fallback)
       ansible.builtin.copy:
@@ -112,6 +123,7 @@
           echo '/swapfile none swap sw 0 0' >> /etc/fstab
         fi
       args:
+        executable: /bin/bash
         creates: /swapfile
 
     # ── Phase 2: OpenClaw prep ───────────────────────────────
@@ -153,6 +165,7 @@
         apt-get update -qq
         apt-get install -y -qq nodejs
       args:
+        executable: /bin/bash
         creates: /usr/bin/node
 
     # ── Phase 3: Caddy reverse proxy ─────────────────────────
@@ -166,6 +179,7 @@
         apt-get update -qq
         apt-get install -y -qq caddy
       args:
+        executable: /bin/bash
         creates: /usr/bin/caddy
 
     - name: Write Caddyfile (domain mode — Let's Encrypt)


### PR DESCRIPTION
## What

**Bucket A of #42** (deploy-hardening). Fixes three `ansible/bootstrap.yml` bugs that block **every** fresh-droplet bootstrap — found running the playbook end-to-end against a live DigitalOcean droplet. None are caught by `--syntax-check` (they're runtime/env), which is why they survived to here.

## Bugs fixed

1. **dash `&>` infinite loop.** The apt-lock wait used `while fuser /var/lib/dpkg/lock-frontend &>/dev/null 2>&1; do sleep 5; done`. Ansible's `shell` runs under `/bin/sh` = **dash**, which doesn't support `&>` — it backgrounds `fuser` and the `while` tests an always-true empty redirect, so bootstrap **hangs at task 1 forever** even when the lock is free. → POSIX `>/dev/null 2>&1`.
2. **Missing `~/.ssh` dir.** The "copy root's authorized_keys to admin" fallback wrote to `/home/<admin>/.ssh/authorized_keys` without creating `.ssh` → `Destination directory does not exist`. → added a `file: state=directory` task (0700, owned by admin) before the copy.
3. **bash convention (root-cause).** Every `shell:` task now sets `args: executable: /bin/bash`, so a future bashism can't silently regress under dash (the class of bug #1 was).

## Validation

- This exact set bootstrapped `157.230.10.139` cleanly (`failed=0`) during the live stock-picker deploy.
- Both playbooks pass `ansible-playbook --syntax-check`.

## Scope

Bucket A only. Remaining #42 work (separate PRs): the `openclaw-team.yml` `--vision` `set_fact` refactor + `team_is_generic` hardening (moved here from #41 item #4); GNU-rsync + model-selection docs; and CI hardening (shellcheck, container integration test, pinned ansible-core / `requirements.yml`).