### PR TITLE
openclaw-team.yml: build --vision via set_fact (root-cause fix for split_args bug class) (#42)

### DIFF
--- a/ansible/openclaw-team.yml
+++ b/ansible/openclaw-team.yml
@@ -157,22 +157,29 @@
         mode: '0700'
 
     # ── Deploy the team (delegates to lib/deploy-team.sh) ──────────
+    # vision_arg holds the optional `--vision <shell-quoted>` for the deployer,
+    # built here in pure Jinja so the shell block below stays free of inline
+    # {% %} blocks and prose comments — both are parsed by Ansible's split_args
+    # and were the source of past quote/apostrophe load-time failures. Set only
+    # for an inline `vision`; a vision_file is copied over VISION.md post-deploy.
+    - name: Build the optional --vision argument
+      ansible.builtin.set_fact:
+        vision_arg: >-
+          {{ ('--vision ' ~ (vision | quote))
+             if (vision is defined and (vision | length > 0)
+                 and (vision_file is not defined or (vision_file | length == 0)))
+             else '' }}
+
+    # Prefer the team setup.sh (a thin shim for built-in teams; bespoke for
+    # modernizer); pure-data teams fall back to the deployer. Mirrors install-team.sh.
     - name: Deploy {{ team }}
       ansible.builtin.shell: |
         set -euo pipefail
         TEAM_DIR="{{ repo_remote }}/{{ team }}"
-        EXTRA=()
-        {% if (vision is defined) and (vision | length > 0) and ((vision_file is not defined) or (vision_file | length == 0)) %}
-        EXTRA+=(--vision {{ vision | quote }})
-        {% endif %}
-        # Prefer the team setup.sh when present — for built-in teams
-        # this is a thin shim over the generic deployer, but a team may
-        # ship bespoke logic (e.g. modernizer). Pure-data teams fall
-        # back to the deployer directly. Mirrors install-team.sh.
         if [[ -f "${TEAM_DIR}/setup.sh" ]]; then
-          bash "${TEAM_DIR}/setup.sh" "${EXTRA[@]+"${EXTRA[@]}"}"
+          bash "${TEAM_DIR}/setup.sh" {{ vision_arg }}
         else
-          bash "{{ repo_remote }}/lib/deploy-team.sh" --team-dir "${TEAM_DIR}" "${EXTRA[@]+"${EXTRA[@]}"}"
+          bash "{{ repo_remote }}/lib/deploy-team.sh" --team-dir "${TEAM_DIR}" {{ vision_arg }}
         fi
       args:
         executable: /bin/bash


### PR DESCRIPTION
## What

Part of **#42** — the item-#4 `set_fact` refactor (moved here from #41). Eliminates the root cause of the `split_args` apostrophe/quote class of bug in `ansible/openclaw-team.yml`.

## Problem

The "Deploy" task built the optional `--vision` argument inside the `shell:` scalar using an inline `{% if %}` block **plus prose comments**. Ansible parses `shell`/`command` module strings with `split_args` at **load time**, so a stray apostrophe or quote in those comments (or the jinja) fails the entire playbook at load — exactly the bug already fixed once (the `team's` apostrophe). The structure invited recurrence.

## Fix

- A `set_fact` builds `vision_arg` (`--vision <shell-quoted>` or `""`) in **pure Jinja**, using the `quote` filter for shell-safety.
- The `shell:` block is reduced to a trivial, **comment-free** dispatch that just expands `{{ vision_arg }}`.

No `{% %}`, no prose, no nested-quote bash array in the shell block — nothing for `split_args` to choke on. The bug class is now structurally impossible.

## Validation

- `ansible-playbook --syntax-check` passes.
- Isolated `set_fact` test renders correctly for:
  - inline `vision` incl. apostrophe + semicolon → `--vision 'Run a desk; it'\''s research-only'` (correct single quoted arg)
  - no `vision` → `` (empty)
  - `vision_file` set → `` (inline `vision` ignored; the file is copied over `VISION.md` post-deploy as before)

## Scope

The `set_fact` refactor only. **`team_is_generic` hardening** (the other half of #42 item #4 — it currently substring-matches `setup.sh` for `deploy-team.sh`) is a smaller, separate follow-up so this PR stays focused on the root-cause fix.