### PR TITLE
docs: GNU-rsync requirement + model-selection note (#42 bucket B)

### DIFF
--- a/DO-SETUP.md
+++ b/DO-SETUP.md
@@ -41,7 +41,7 @@ curl -fsSL https://openclaw.ai/install.sh | bash
 
 The installer runs onboarding automatically — you'll choose your messaging channel, enter your Telegram/Discord token, API key, etc.
 
-> **Choosing your model.** Onboarding is also where you pick the **AI provider and model** — the model choice is entirely yours (Claude, OpenRouter, OpenAI, a local model, etc.); nothing here requires a particular one. To see what you ended up on, check `model.primary` in `~/.openclaw/openclaw.json` or the `[gateway] agent model: …` line in `openclaw gateway logs`. To change it later, edit `model.primary` in `~/.openclaw/openclaw.json` (and make sure the matching provider key is set), then restart the gateway.
+> **Choosing your model.** Onboarding is also where you pick the **AI provider and model** — the model choice is entirely yours (Claude, OpenRouter, OpenAI, a local model, etc.); nothing here requires a particular one. To see what you ended up on, check `agents.defaults.model.primary` in `~/.openclaw/openclaw.json` or the `[gateway] agent model: …` line in `openclaw logs`. To change it later, edit `agents.defaults.model.primary` in `~/.openclaw/openclaw.json` (and make sure the matching provider key is set), then restart the gateway.
 
 #### Step 3 — Deploy team (still as openclaw user)
 
@@ -124,7 +124,7 @@ sudo -u openclaw nano /home/openclaw/.openclaw/shared/VISION.md
 ```bash
 sudo -u openclaw -i openclaw gateway status
 sudo -u openclaw -i openclaw gateway restart
-sudo -u openclaw -i openclaw gateway logs
+sudo -u openclaw -i openclaw logs
 ```
 
 ## Security
@@ -145,7 +145,7 @@ All three steps are safe to run multiple times. Users are checked before creatio
 ### Gateway isn't responding
 ```bash
 sudo -u openclaw -i openclaw gateway status
-sudo -u openclaw -i openclaw gateway logs
+sudo -u openclaw -i openclaw logs
 ```
 
 ### Can't SSH as admin user

--- a/DO-SETUP.md
+++ b/DO-SETUP.md
@@ -41,6 +41,8 @@ curl -fsSL https://openclaw.ai/install.sh | bash
 
 The installer runs onboarding automatically — you'll choose your messaging channel, enter your Telegram/Discord token, API key, etc.
 
+> **Choosing your model.** Onboarding is also where you pick the **AI provider and model** — the model choice is entirely yours (Claude, OpenRouter, OpenAI, a local model, etc.); nothing here requires a particular one. To see what you ended up on, check `model.primary` in `~/.openclaw/openclaw.json` or the `[gateway] agent model: …` line in `openclaw gateway logs`. To change it later, edit `model.primary` in `~/.openclaw/openclaw.json` (and make sure the matching provider key is set), then restart the gateway.
+
 #### Step 3 — Deploy team (still as openclaw user)
 
 ```bash

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -12,9 +12,15 @@ want declarative inventory + per-host overrides, use these playbooks.
 
 ## Requirements
 
-- Ansible 2.14+ with the `ansible.posix` collection installed
-  (`ansible-galaxy collection install ansible.posix`)
-- `rsync` on the control machine and on the targets
+- **Ansible** — tested on ansible-core 2.20. Install the required collections
+  with `ansible-galaxy collection install -r ansible/requirements.yml`
+  (`ansible.posix` for `synchronize`, `community.general` for `ufw`).
+- **GNU `rsync` on the control machine** — `openclaw-team.yml`'s `synchronize`
+  task passes `--chown`, which macOS's default **openrsync** rejects
+  (`rsync: unrecognized option '--chown'`). On macOS: `brew install rsync`, then
+  make sure it precedes `/usr/bin/rsync` on `PATH` — e.g. run with
+  `PATH="$(brew --prefix)/bin:$PATH" ansible-playbook …`. Targets need `rsync`
+  too (Ubuntu ships it).
 - Targets running Ubuntu 24.04 with SSH access as a sudo-capable user
 
 ---


### PR DESCRIPTION
Part of **#42** (bucket B). Documents two gaps the live droplet deploy hit:

- **`ansible/README.md`** — control node needs **GNU rsync**, not macOS openrsync (the `synchronize` task's `--chown` is GNU-only). `brew install rsync` + PATH note. Plus tested ansible-core (2.20) and the `requirements.yml` install (`community.general` is needed for `ufw`).
- **`DO-SETUP.md`** — a **model-agnostic** note that onboarding is where the AI provider+model is chosen (we landed on Gemini via OpenRouter), how to see which model you're on (`model.primary` / gateway log), and how to change it. Model choice is the operator's — nothing mandates Claude.

Pairs with the CI-hardening PR which adds `ansible/requirements.yml` (referenced here).