### PR TITLE
ci: shellcheck + pinned ansible-core + requirements.yml (#42 bucket C)

### DIFF
--- a/.github/workflows/validate-teams.yml
+++ b/.github/workflows/validate-teams.yml
@@ -33,6 +33,11 @@ jobs:
             bash -n "$f"
           done
 
+      - name: ShellCheck shell scripts (error severity)
+        run: |
+          shopt -s nullglob
+          shellcheck -S error lib/*.sh */setup.sh bootstrap.sh install-team.sh
+
   validate-ansible:
     name: Ansible playbook syntax
     runs-on: ubuntu-latest
@@ -50,8 +55,8 @@ jobs:
       - name: Install Ansible + collections
         run: |
           python -m pip install --upgrade pip
-          pip install ansible-core
-          ansible-galaxy collection install ansible.posix community.general
+          pip install 'ansible-core>=2.20,<2.21'
+          ansible-galaxy collection install -r ansible/requirements.yml
 
       - name: Syntax-check playbooks
         run: |

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,10 @@
+---
+# Ansible collection dependencies for the deploy playbooks.
+# Install with:  ansible-galaxy collection install -r ansible/requirements.yml
+collections:
+  # synchronize (repo rsync to targets) in openclaw-team.yml
+  - name: ansible.posix
+    version: ">=1.5.0"
+  # ufw (firewall) in bootstrap.yml
+  - name: community.general
+    version: ">=8.0.0"


### PR DESCRIPTION
## What

**#42 bucket C** (CI hardening — minus the big container test). Strengthens the gate and pins the Ansible toolchain.

- **`ansible/requirements.yml`** (new) — declares `ansible.posix` (`synchronize`) + `community.general` (`ufw`). The workflow installs from it; `ansible/README` (in the docs PR #49) points operators at it.
- **Workflow `validate-teams.yml`:**
  - **Pin `ansible-core>=2.20,<2.21`** — the `split_args` apostrophe class only surfaces on newer cores, so pinning makes CI reproduce it reliably.
  - **`shellcheck -S error`** over `lib/*.sh`, `*/setup.sh`, `bootstrap.sh`, `install-team.sh`. **Error** severity: green today (verified locally), catches real bugs. The ~9 warning-level findings are benign/false-positive — notably `SC2088` (tilde-in-quotes) is *intentional*: `~/.openclaw/...` is a literal string OpenClaw expands itself, not the shell.

## Validation

- Workflow + `requirements.yml` YAML valid.
- `shellcheck -S error` over all shell scripts → clean (exit 0).
- The CI run on this PR exercises the new shellcheck step and the `requirements.yml` install end-to-end.

## Deferred (still open in #42)

- **Container integration test** that actually runs `bootstrap.yml` — it needs systemd/ufw/swap in a privileged container, a meaningfully larger lift, so it stays its own item.
- **`team_is_generic` hardening** — small follow-up (substring match → explicit marker); current detection is adequate for all real teams.

Pairs with **#49** (docs), which documents `requirements.yml` and the tested ansible-core version.