### PR TITLE
Ship BWS exec secrets resolver + per-developer docs (#43)

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -39,44 +39,70 @@ startup through the `exec` provider rather than being written to disk.
 - You're running multiple droplets and want a single rotation point.
 - You need an audit log of which key was read when.
 
-### Sketch
+This repo ships the resolver: [`lib/openclaw-bws-resolver.mjs`](../lib/openclaw-bws-resolver.mjs).
+Each agent developer brings their **own** BWS project + access token; the secret-id
+naming convention below is shared so every deployment's `openclaw.json` looks the same.
 
-1. Create a Bitwarden Secrets Manager organization and project, generate an access
-   token, and note its ID.
-2. Store the token at `~/.config/openclaw/bws.env` (mode `600`):
+#### 1. Store your keys in BWS (per developer)
 
-   ```env
-   BWS_ACCESS_TOKEN=…
-   BWS_PROJECT_ID=…
-   ```
+Create a Bitwarden Secrets Manager organization + project and a machine-account
+access token. Store each credential as a secret whose **key** follows this
+convention (the resolver matches on the secret's `key` field):
 
-3. Install a small `bws-resolver` helper on the droplet (path:
-   `~/.local/bin/openclaw-bws-resolver`) that takes a secret ID and prints its
-   value.
-4. Add an `EnvironmentFile=` line to the user systemd unit so the token is loaded
-   at gateway start:
+| Credential | BWS secret key |
+|------------|----------------|
+| Model provider API key | `openclaw/providers/<provider>/apiKey` (e.g. `.../openrouter/apiKey`) |
+| Channel bot token | `openclaw/channels/<channel>/botToken` (e.g. `.../telegram/botToken`) |
 
-   ```ini
-   [Service]
-   EnvironmentFile=%h/.config/openclaw/bws.env
-   ```
+#### 2. Install the resolver + token on the droplet
 
-5. In `~/.openclaw/openclaw.json`, replace literal keys with `exec` refs:
+```bash
+install -m 0755 lib/openclaw-bws-resolver.mjs /usr/local/bin/openclaw-bws-resolver.mjs
+install -d -m 0700 ~/.config/openclaw
+printf 'BWS_ACCESS_TOKEN=%s\n' "$YOUR_TOKEN" > ~/.config/openclaw/bws.env   # mode 600
+chmod 600 ~/.config/openclaw/bws.env
+```
 
-   ```json
-   "credentials": {
-     "ANTHROPIC_API_KEY": {
-       "source": "exec",
-       "provider": "bws",
-       "id": "ANTHROPIC_API_KEY"
-     }
-   }
-   ```
+Add an `EnvironmentFile=` to the gateway's user systemd unit so the token (the
+one secret that lives on disk) loads at start:
 
-The full Ansible implementation — including the resolver script and the
-provider definition — lives in
-`~/git/DigitalOcean_setup/openclaw/openclaw-secrets.yml`. This repo intentionally
-does not ship a resolver yet; lift it from the playbook when you need it.
+```ini
+[Service]
+EnvironmentFile=%h/.config/openclaw/bws.env
+```
+
+#### 3. Declare the provider + SecretRefs in `openclaw.json`
+
+```json5
+{
+  secrets: { providers: { bws: {
+    source: "exec",
+    command: "/usr/local/bin/openclaw-bws-resolver.mjs",
+    passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN", "BWS_PROJECT_ID"],
+    jsonOnly: true,
+  } } },
+  models: { providers: { openrouter: {
+    apiKey: { source: "exec", provider: "bws", id: "openclaw/providers/openrouter/apiKey" },
+  } } },
+  channels: { telegram: {
+    enabled: true,
+    botToken: { source: "exec", provider: "bws", id: "openclaw/channels/telegram/botToken" },
+  } },
+}
+```
+
+At gateway start every SecretRef is resolved (the gateway batches all ids into
+one resolver call); resolution failure keeps the previous working snapshot.
+`openclaw secrets reload` re-resolves without a restart. The resolver's I/O
+contract (stdin `{ids:[…]}` → stdout `{values:{…}}`) and which fields accept a
+SecretRef are documented at
+<https://docs.openclaw.ai/gateway/secrets> and
+<https://docs.openclaw.ai/reference/secretref-credential-surface>.
+
+The resolver reads `BWS_ACCESS_TOKEN` (required), `BWS_BIN` (default `bws`), and
+optional `BWS_PROJECT_ID` to scope the listing. It runs `bws secret list` once
+and maps each requested id to the matching secret `key` — no key value is ever
+written to disk.
 
 ---
 

--- a/lib/openclaw-bws-resolver.mjs
+++ b/lib/openclaw-bws-resolver.mjs
@@ -45,11 +45,24 @@ function readStdin() {
   }
 }
 
-function fail(message) {
-  // Protocol-level failure: no values, a single synthetic error. The gateway
-  // keeps its previous working snapshot when resolution fails.
-  process.stdout.write(JSON.stringify({ protocolVersion: PROTOCOL, values: {}, errors: { "*": { message } } }) + "\n");
+function failAllIds(ids, message) {
+  // Resolution failure once the requested ids are known. OpenClaw's exec
+  // resolver reads errors[id] per id — an errors["*"] entry is dropped and the
+  // id then surfaces as a misleading `response missing id "..."`, hiding the
+  // real diagnostic. So fan the message out to every requested id. The gateway
+  // keeps its previous working snapshot when ids fail to resolve.
+  const errors = {};
+  for (const id of ids) errors[id] = { message };
+  process.stdout.write(JSON.stringify({ protocolVersion: PROTOCOL, values: {}, errors }) + "\n");
   process.exit(0);
+}
+
+function failProvider(message) {
+  // Provider-level failure before the requested ids are known (stdin could not
+  // be parsed, so there is no id to attach the error to). Signal out-of-band
+  // with a non-zero exit + stderr; the gateway keeps its previous snapshot.
+  process.stderr.write(message + "\n");
+  process.exit(1);
 }
 
 let req;
@@ -57,7 +70,7 @@ const raw = readStdin();
 try {
   req = JSON.parse(raw || "{}");
 } catch {
-  fail("resolver: stdin was not valid JSON");
+  failProvider("resolver: stdin was not valid JSON");
 }
 
 const ids = Array.isArray(req.ids) ? req.ids : [];
@@ -67,7 +80,7 @@ if (ids.length === 0) {
 }
 
 if (!process.env.BWS_ACCESS_TOKEN) {
-  fail("resolver: BWS_ACCESS_TOKEN is not set");
+  failAllIds(ids, "resolver: BWS_ACCESS_TOKEN is not set");
 }
 
 const bws = process.env.BWS_BIN || "bws";
@@ -79,7 +92,7 @@ try {
   const out = execFileSync(bws, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
   listed = JSON.parse(out);
 } catch (e) {
-  fail(`resolver: '${bws} secret list' failed: ${(e && e.message) || e}`);
+  failAllIds(ids, `resolver: '${bws} secret list' failed: ${(e && e.message) || e}`);
 }
 
 // Map BWS secret key -> value. `bws secret list` yields [{ key, value, ... }].

--- a/lib/openclaw-bws-resolver.mjs
+++ b/lib/openclaw-bws-resolver.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// ============================================================
+// OpenClaw exec secrets resolver for Bitwarden Secrets Manager (BWS)
+// ============================================================
+// Implements OpenClaw's exec-provider I/O contract so API keys and channel
+// tokens never touch the droplet's disk — they're fetched from BWS at gateway
+// start and held in memory. Reference it from openclaw.json:
+//
+//   secrets: { providers: { bws: {
+//     source: "exec",
+//     command: "/usr/local/bin/openclaw-bws-resolver.mjs",
+//     passEnv: ["BWS_ACCESS_TOKEN", "PATH", "BWS_BIN", "BWS_PROJECT_ID"],
+//     jsonOnly: true } } }
+//
+// then resolve any SecretRef-capable field, e.g.:
+//   models.providers.openrouter.apiKey:
+//     { source: "exec", provider: "bws", id: "openclaw/providers/openrouter/apiKey" }
+//   channels.telegram.botToken:
+//     { source: "exec", provider: "bws", id: "openclaw/channels/telegram/botToken" }
+//
+// Contract (https://docs.openclaw.ai/gateway/secrets):
+//   stdin : { "protocolVersion": 1, "provider": "bws", "ids": ["<key>", ...] }
+//   stdout: { "protocolVersion": 1, "values": { "<key>": "<secret>" },
+//             "errors": { "<key>": { "message": "..." } } }   // errors optional
+//
+// The requested `ids` are matched against each BWS secret's `key` field. The
+// gateway batches ids into one call, so we list once and map by key.
+//
+// Env:
+//   BWS_ACCESS_TOKEN  required — the BWS machine-account token (read by `bws`)
+//   BWS_BIN           optional — path to the bws CLI (default: "bws")
+//   BWS_PROJECT_ID    optional — scope `secret list` to one project
+// ============================================================
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const PROTOCOL = 1;
+
+function readStdin() {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function fail(message) {
+  // Protocol-level failure: no values, a single synthetic error. The gateway
+  // keeps its previous working snapshot when resolution fails.
+  process.stdout.write(JSON.stringify({ protocolVersion: PROTOCOL, values: {}, errors: { "*": { message } } }) + "\n");
+  process.exit(0);
+}
+
+let req;
+const raw = readStdin();
+try {
+  req = JSON.parse(raw || "{}");
+} catch {
+  fail("resolver: stdin was not valid JSON");
+}
+
+const ids = Array.isArray(req.ids) ? req.ids : [];
+if (ids.length === 0) {
+  process.stdout.write(JSON.stringify({ protocolVersion: PROTOCOL, values: {} }) + "\n");
+  process.exit(0);
+}
+
+if (!process.env.BWS_ACCESS_TOKEN) {
+  fail("resolver: BWS_ACCESS_TOKEN is not set");
+}
+
+const bws = process.env.BWS_BIN || "bws";
+const args = ["secret", "list", "--output", "json"];
+if (process.env.BWS_PROJECT_ID) args.splice(2, 0, process.env.BWS_PROJECT_ID);
+
+let listed;
+try {
+  const out = execFileSync(bws, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  listed = JSON.parse(out);
+} catch (e) {
+  fail(`resolver: '${bws} secret list' failed: ${(e && e.message) || e}`);
+}
+
+// Map BWS secret key -> value. `bws secret list` yields [{ key, value, ... }].
+const byKey = new Map();
+for (const s of Array.isArray(listed) ? listed : []) {
+  if (s && typeof s.key === "string") byKey.set(s.key, s.value);
+}
+
+const values = {};
+const errors = {};
+for (const id of ids) {
+  if (byKey.has(id)) values[id] = byKey.get(id);
+  else errors[id] = { message: "not found in BWS (no secret with this key)" };
+}
+
+const resp = { protocolVersion: PROTOCOL, values };
+if (Object.keys(errors).length > 0) resp.errors = errors;
+process.stdout.write(JSON.stringify(resp) + "\n");


### PR DESCRIPTION
## What

Part of **#43**. Ships the **BWS exec secrets resolver** the repo was missing (`docs/advanced.md` literally said *"this repo intentionally does not ship a resolver yet"*), as **reusable per-developer infrastructure** — each agent developer brings their own Bitwarden Secrets Manager project + access token, and a shared secret-id convention keeps every deployment's `openclaw.json` identical.

With this, API keys and channel tokens are **never written to the droplet's disk** — they're resolved from BWS at gateway start and held in memory. The only on-disk secret is the `BWS_ACCESS_TOKEN` itself.

## Pieces

- **`lib/openclaw-bws-resolver.mjs`** — implements OpenClaw's exec-provider I/O contract: stdin `{protocolVersion, provider, ids:[…]}` → stdout `{protocolVersion, values:{id:val}, errors:{id:{message}}}`. Runs `bws secret list` once (the gateway batches all ids), maps each requested id to the matching secret `key`, and honors `BWS_ACCESS_TOKEN` / `BWS_BIN` / `BWS_PROJECT_ID`.
- **`docs/advanced.md`** — rewritten BWS section: per-developer setup, the `openclaw/providers/<p>/apiKey` + `openclaw/channels/<c>/botToken` key convention, the `secrets.providers.bws` exec block, and SecretRef examples for `models.providers.openrouter.apiKey` + `channels.telegram.botToken` (both verified SecretRef-capable via the credential-surface reference).

## Validation

- Tested against a **mock `bws`**: batched hit/miss (values + per-id error), missing-`BWS_ACCESS_TOKEN` (protocol error), empty-ids (empty values) — all match the documented contract.
- `node --check` passes.

## Deferred (still #43)

- **Ansible auto-install** — install the resolver + `bws` CLI + the `EnvironmentFile` and stop writing provider/channel keys to `.env` when BWS is in use.
- **stock-picker declarative `openclaw.json`** that consumes this (model = `openrouter/google/gemini-3.5-flash`), plus landing the stock-picker team on `main`.
- **Live end-to-end verification** — needs a real BWS project + a droplet (the clean-rebuild pass).