### PR TITLE
Phase 3 docs + Ansible 2.19 deploy hardening & BWS secrets recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,14 @@ Declarative files (`SOUL/IDENTITY/AGENTS/HEARTBEAT`) always refresh; `USER.md`
 and `VISION.md` are seeded once so live customizations survive re-deploys (use
 `--vision` to overwrite the mission deliberately).
 
+> **Deploying to a real droplet?** Read
+> [`docs/deployment-notes.md`](docs/deployment-notes.md) first. It records the
+> actual fresh-droplet sequence — including the easy-to-miss **`openclaw` gateway
+> install** step that no playbook runs — plus the Ansible core 2.19 gotchas and the
+> `-e key="value with spaces"` truncation trap. For API keys resolved from Bitwarden
+> at gateway start (nothing written to `~/.openclaw/.env`), follow
+> [`docs/secrets-bws.md`](docs/secrets-bws.md).
+
 ---
 
 ## Authoring checklist

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -8,6 +8,11 @@ If you're deploying a single droplet, **use the shell flow** — open
 [DO-SETUP.md](../DO-SETUP.md). If you're deploying many hosts, or you
 want declarative inventory + per-host overrides, use these playbooks.
 
+> **Before a real run, read [`../docs/deployment-notes.md`](../docs/deployment-notes.md)** —
+> the fresh-droplet sequence (incl. the separate `openclaw` gateway install), Ansible
+> core 2.19 gotchas, and the `-e key="value with spaces"` truncation trap. For secrets
+> resolved from Bitwarden at gateway start, see [`../docs/secrets-bws.md`](../docs/secrets-bws.md).
+
 ---
 
 ## Requirements

--- a/ansible/files/openclaw-bws-secret-provider.sh
+++ b/ansible/files/openclaw-bws-secret-provider.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# OpenClaw "exec" secret provider backed by Bitwarden Secrets Manager (BWS).
+#
+# Wire it up with:
+#   openclaw config set secrets.providers.bws \
+#     --provider-source exec \
+#     --provider-command <abs path to this script> \
+#     --provider-pass-env BWS_ACCESS_TOKEN --provider-pass-env BWS_PROJECT_ID \
+#     --provider-json-only
+# then reference secrets, e.g.:
+#   openclaw config set models.providers.openrouter.apiKey \
+#     --ref-source exec --ref-provider bws --ref-id OPENROUTER_API_KEY
+#
+# Protocol (OpenClaw exec provider, protocolVersion 1):
+#   stdin : {"protocolVersion":1,"provider":"bws","ids":["KEY_NAME", ...]}
+#   stdout: {"protocolVersion":1,"values":{"KEY_NAME":"<secret>"},"errors":{"KEY_NAME":{"message":"…"}}}
+#
+# Notes:
+#   * OpenClaw spawns this with a near-empty environment (only --provider-pass-env vars),
+#     so we set PATH and use an absolute bws path. Requires BWS_ACCESS_TOKEN + BWS_PROJECT_ID
+#     (supply them to the gateway via a systemd EnvironmentFile and pass-env, above).
+#   * Resolves by secret *key name* (the ref id), so rotating a secret's UUID won't break refs.
+#   * Install chmod 700, owned by the gateway user (OpenClaw enforces a not-writable-by-others,
+#     absolute, non-symlink command path).
+set -euo pipefail
+export PATH=/usr/local/bin:/usr/bin:/bin
+
+BWS="${BWS_BIN:-/home/openclaw/.local/bin/bws}"   # override with BWS_BIN if installed elsewhere
+
+req="$(cat)"
+mapfile -t ids < <(printf '%s' "$req" | jq -r '.ids[]?')
+
+# One list call; filter by key name locally. bws output may carry ANSI — strip it.
+all="$("$BWS" secret list "$BWS_PROJECT_ID" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g')"
+
+out='{}'
+for id in "${ids[@]}"; do
+  val="$(printf '%s' "$all" | jq -r --arg k "$id" 'map(select(.key==$k))[0].value // empty')"
+  if [[ -n "$val" ]]; then
+    out="$(printf '%s' "$out" | jq --arg i "$id" --arg v "$val" '.values[$i]=$v')"
+  else
+    out="$(printf '%s' "$out" | jq --arg i "$id" '.errors[$i]={message:"secret not found in BWS project"}')"
+  fi
+done
+
+printf '%s\n' "$out" | jq -c '{protocolVersion:1} + .'

--- a/ansible/openclaw-team.yml
+++ b/ansible/openclaw-team.yml
@@ -148,6 +148,9 @@
           - "--exclude=node_modules"
           - "--exclude=.env"
           - "--exclude=*.backup.*"
+          - "--exclude=ansible/secrets"
+          - "--exclude=*.vault.yml"
+          - "--exclude=.claude"
           - "--chown={{ openclaw_user }}:{{ openclaw_user }}"
 
     - name: Ensure ~/.openclaw exists

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -73,10 +73,18 @@ startup through the `exec` provider rather than being written to disk.
    }
    ```
 
-The full Ansible implementation — including the resolver script and the
-provider definition — lives in
-`~/git/DigitalOcean_setup/openclaw/openclaw-secrets.yml`. This repo intentionally
-does not ship a resolver yet; lift it from the playbook when you need it.
+> **A complete, validated recipe now lives in this repo:**
+> [`docs/secrets-bws.md`](secrets-bws.md) walks the whole flow for OpenClaw 2026.5.x —
+> the exec-provider stdio contract, the exact `openclaw config set` commands, the
+> systemd `EnvironmentFile`, and getting the `bws` CLI onto the droplet. The resolver
+> script it references is shipped at
+> [`ansible/files/openclaw-bws-secret-provider.sh`](../ansible/files/openclaw-bws-secret-provider.sh)
+> (resolves secrets by key name; safe under the near-empty env OpenClaw spawns providers in).
+> Note the sketch below predates that recipe and uses an older `credentials` shape;
+> prefer the secrets-bws.md `secrets.providers` + `--ref` mechanism.
+
+A fuller Ansible implementation also lives in the sister repo
+`~/git/DigitalOcean_setup/openclaw/openclaw-secrets.yml` if you want to compare.
 
 ---
 

--- a/docs/deployment-notes.md
+++ b/docs/deployment-notes.md
@@ -1,0 +1,101 @@
+# Deployment notes — fresh droplet, real-world gotchas
+
+Field notes from deploying a team end-to-end onto a bare Ubuntu 24.04 DigitalOcean
+droplet with a **modern Ansible (core 2.19)** controller. The happy path is in
+[DO-SETUP.md](../DO-SETUP.md) and [ansible/README.md](../ansible/README.md); this
+file records what actually bites you, so the next deploy is faster. If you're a Claude
+Code agent doing a bootstrap, **read this first.**
+
+---
+
+## The full sequence (and the gap)
+
+A fresh droplet → live team is **four steps**, not three. The middle one is easy to miss
+because no playbook runs it:
+
+1. **Provision** — `ansible/bootstrap.yml` (hardening, `openclaw`/`claude` users, Node 22, Caddy).
+2. **Install the OpenClaw gateway** — *separate, not in any playbook*:
+   ```bash
+   ssh root@HOST 'sudo -u openclaw bash -lc "curl -fsSL https://openclaw.ai/install.sh | bash"'
+   ```
+   `bootstrap.yml` installs Node + creates the user but **not** the `openclaw` binary, and
+   `openclaw-team.yml`'s gateway tasks assume `~/.npm-global/bin/openclaw` exists. Skip this
+   and the team deploy's gateway start fails. (Candidate for a future playbook step.)
+3. **Deploy the team** — `ansible/openclaw-team.yml`.
+4. **Secrets + channel pairing** — for API keys resolved from Bitwarden at gateway start
+   (no keys on disk), follow [secrets-bws.md](secrets-bws.md). Then approve the first
+   Telegram contact: a user DMs the bot, the bot replies with a pairing code, and you run
+   `openclaw pairing approve telegram <CODE>` on the droplet (as the `openclaw` user).
+
+---
+
+## Ansible core 2.19 compatibility
+
+The playbooks were written for Ansible 2.14+; core **2.19** is much stricter and several
+latent issues surface on a real run. **These are already fixed on `main` (PRs #41/#42)** —
+they're recorded here as lessons (and as a warning if you're on an older revision):
+
+- **`openclaw-team.yml` — "failed at splitting arguments, either an unbalanced jinja2 block or quotes".**
+  The `Deploy` task embedded a Jinja `{% if %}` block plus the bash idiom
+  `"${EXTRA[@]+"${EXTRA[@]}"}"` (nested quotes) inside a `shell:` scalar; 2.19's arg splitter
+  rejects it. Fixed on `main` by building `--vision` via `set_fact` and a comment-free deploy
+  block. *(Takeaway: don't embed `{% %}` control flow or nested quotes in a `shell:` scalar;
+  precompute with `set_fact` or use `command:`/`argv`.)*
+- **`bootstrap.yml` apt-lock wait hung forever.** `while fuser … &>/dev/null` — `&>` is a
+  *bashism*, but Ansible runs `shell:` under `/bin/sh` = **dash**, which parses it as
+  "background `fuser`" + an always-true no-op, so the loop never exits even with no lock held.
+  Fixed on `main` (POSIX `>/dev/null 2>&1` / forced bash). *(Takeaway: any `shell:` using
+  bash-only syntax needs `args: { executable: /bin/bash }` or POSIX syntax.)*
+- **`bootstrap.yml` authorized_keys fallback** failed with `Destination directory
+  /home/<admin>/.ssh does not exist` — the `copy` module won't create the parent dir. Fixed on
+  `main` by creating the admin `.ssh` dir first.
+- **`ansible.posix` collection.** Use **≥ 2.2.0** for core 2.19 (`main` pins ansible-core and
+  installs collections via `requirements.yml`). 2.1.0's `authorized_key`/`synchronize` misbehave.
+
+---
+
+## The `-e key="value with spaces"` trap (this one cost the most time)
+
+Passing an SSH public key (which contains spaces) as `-e ssh_key="ssh-ed25519 AAAA… user@host"`
+**silently truncates it to `ssh-ed25519`** — Ansible's `key=value` extra-vars parser splits
+on whitespace into multiple pairs. The downstream symptom is a cryptic
+`authorized_key … Module failed: list index out of range` (the module receives a key with no body).
+
+**Always pass multi-word vars via an extra-vars file or JSON, never `-e key="a b c"`:**
+```bash
+ansible-playbook ... -e @secrets.yml          # YAML file  ✅
+ansible-playbook ... -e '{"ssh_key":"ssh-ed25519 AAAA… u@h"}'   # JSON  ✅
+ansible-playbook ... -e ssh_key="ssh-ed25519 AAAA… u@h"          # TRUNCATED ❌
+```
+Confirm with `ansible localhost -e ssh_key="$(cat key.pub)" -m debug -a var=ssh_key` — you'll
+see it cut to `"ssh-ed25519"`.
+
+---
+
+## Fresh-droplet timing & connection
+
+- **First-boot apt lock.** A new DO droplet runs cloud-init / unattended-upgrades on first
+  boot and holds the dpkg lock for **several minutes**. `bootstrap.yml`'s lock-wait task rides
+  this out — **run bootstrap in the background**, not a foreground command with a short timeout
+  (a timeout kill mid-`apt` leaves a half-provisioned box).
+- **Connect as `root` for bootstrap** (`-u root`). After hardening, root key login still works
+  (`PermitRootLogin prohibit-password` only disables passwords). The team deploy can also
+  connect as root (it `become`s `openclaw`), avoiding a dependency on the admin user's key
+  being in place yet.
+- **Don't rsync secrets to hosts.** `openclaw-team.yml` rsyncs the whole repo — keep vault files
+  under `ansible/secrets/` and ensure that dir (plus `*.vault.yml` and `.claude`) is excluded.
+
+---
+
+## Verifying a deploy
+
+```bash
+# gateway up
+ssh root@HOST 'sudo -u openclaw bash -lc "systemctl --user is-active openclaw-gateway.service"'
+# config valid
+ssh root@HOST 'sudo -u openclaw bash -lc "openclaw config validate"'
+# NO live secrets on disk (only commented template lines should match)
+ssh root@HOST 'sudo -u openclaw bash -lc "grep -vE \"^[[:space:]]*#\" ~/.openclaw/.env | grep -nE \"sk-|_KEY=|_TOKEN=\" || echo NONE"'
+# model + channels came up (look for: model configured / [gateway] ready / [telegram] starting provider)
+ssh root@HOST 'sudo -u openclaw bash -lc "journalctl --user -u openclaw-gateway.service -n 30 --no-pager"'
+```

--- a/docs/secrets-bws.md
+++ b/docs/secrets-bws.md
@@ -1,0 +1,123 @@
+# Secrets via Bitwarden Secrets Manager — resolve at gateway start (no keys on disk)
+
+A **complete, validated** recipe (validated against OpenClaw **2026.5.x**) for keeping
+provider API keys and channel tokens out of `~/.openclaw/.env` entirely. Secrets are
+resolved in-memory at gateway start through an OpenClaw **`exec` secret provider**.
+This supersedes the sketch in [advanced.md](advanced.md#1-secrets-via-bitwarden-secrets-manager-bws);
+the resolver it said "this repo does not ship yet" now lives at
+[`../ansible/files/openclaw-bws-secret-provider.sh`](../ansible/files/openclaw-bws-secret-provider.sh).
+
+> Paths below use the **shipped** resolver filename `openclaw-bws-secret-provider.sh`
+> consistently — install it under that name and reference that same path everywhere.
+
+## What touches disk
+
+Nothing but the **BWS bootstrap token**. Provider keys (OpenRouter, Telegram, …) are
+never written. On disk you have only:
+- `~/.config/openclaw/bws.env` (chmod 600) — `BWS_ACCESS_TOKEN` + `BWS_PROJECT_ID`.
+- `~/.config/openclaw/openclaw-bws-secret-provider.sh` (chmod 700) — the resolver.
+- `~/.openclaw/openclaw.json` — holds *references* `{source:exec, provider:bws, id:KEY_NAME}`, not values.
+
+> BWS projects are scoped. The project that backs an agent may differ from whatever
+> `BWS_PROJECT_ID` is in your shell. Always confirm `bws secret list <project-id>` shows
+> the keys you expect before wiring them.
+
+## How OpenClaw's exec provider works (the contract)
+
+The gateway spawns the provider command and talks to it over **stdio**, batched:
+- **stdin:** `{"protocolVersion":1,"provider":"bws","ids":["OPENROUTER_API_KEY", …]}`
+- **stdout:** `{"protocolVersion":1,"values":{"OPENROUTER_API_KEY":"sk-or-…"},"errors":{}}`
+
+Key facts (OpenClaw 2026.5.x):
+- The ref `id` is **not** an argv; ids arrive on stdin. With `--provider-json-only` (default
+  at runtime) the command **must** emit the JSON envelope above.
+- The command is spawned with a **near-empty environment** — only the vars named by
+  `--provider-pass-env` (plus any `--provider-env`). So the wrapper must set its own `PATH`
+  and use absolute tool paths. `bws` itself is happy with just `BWS_ACCESS_TOKEN`/`BWS_PROJECT_ID`.
+- The command path must be **absolute, owned by the gateway user, not group/world-writable,
+  not a symlink** (path-security check) — `~/.config/openclaw/…` + `chmod 700` satisfies it.
+- SecretRef `id` for `models.providers.*.apiKey` and `channels.telegram.botToken` must match
+  `^[A-Z][A-Z0-9_]{0,127}$` — i.e. the **key name** (e.g. `OPENROUTER_API_KEY`), not a UUID.
+
+## Steps
+
+### 0. Put the `bws` CLI on the droplet
+The resolver runs *on the host*, so `bws` must exist there (it's normally only on your
+controller). Easiest is to copy your controller binary (check arch/glibc — a recent build
+runs fine on 24.04):
+```bash
+scp ~/.local/bin/bws root@HOST:/tmp/bws
+ssh root@HOST 'mkdir -p /home/openclaw/.local/bin && install -m755 /tmp/bws /home/openclaw/.local/bin/bws && chown -R openclaw:openclaw /home/openclaw/.local && rm /tmp/bws && sudo -u openclaw /home/openclaw/.local/bin/bws --version'
+```
+
+### 1. Install the resolver + bootstrap creds (chmod 700 / 600, owned `openclaw`)
+Install `ansible/files/openclaw-bws-secret-provider.sh` to
+`~/.config/openclaw/openclaw-bws-secret-provider.sh` (chmod 700), and write
+`~/.config/openclaw/bws.env` (chmod 600) with the **trading project's** token — pipe it over
+stdin so it never lands in a shell history / transcript:
+```bash
+scp ansible/files/openclaw-bws-secret-provider.sh root@HOST:/tmp/p.sh
+ssh root@HOST 'D=/home/openclaw/.config/openclaw; mkdir -p "$D"; install -m700 /tmp/p.sh "$D/openclaw-bws-secret-provider.sh"; rm /tmp/p.sh; chown -R openclaw:openclaw "$D"'
+
+printf 'BWS_ACCESS_TOKEN=%s\nBWS_PROJECT_ID=%s\n' "$TOK" "$PID" | \
+  ssh root@HOST 'umask 077; D=/home/openclaw/.config/openclaw; mkdir -p "$D"; cat > "$D/bws.env"; chown -R openclaw:openclaw "$D"; chmod 600 "$D/bws.env"'
+```
+
+### 2. Verify resolution BEFORE wiring it in
+Replicate the gateway's minimal-env spawn (only the two BWS vars) and confirm output —
+print lengths, never values:
+```bash
+ssh root@HOST 'sudo -u openclaw bash -lc '"'"'set -a; . ~/.config/openclaw/bws.env; set +a; printf "{\"protocolVersion\":1,\"ids\":[\"OPENROUTER_API_KEY\"]}" | env -i BWS_ACCESS_TOKEN="$BWS_ACCESS_TOKEN" BWS_PROJECT_ID="$BWS_PROJECT_ID" bash ~/.config/openclaw/openclaw-bws-secret-provider.sh | jq ".values|map_values(length)"'"'"''
+```
+
+### 3. systemd EnvironmentFile so the gateway can forward the creds
+The gateway runs as a `systemd --user` service. Add a drop-in so it loads the BWS token and
+can pass it through to the provider (the `.service.d` dir must exist — `copy`/`install`
+won't create it):
+```ini
+# ~/.config/systemd/user/openclaw-gateway.service.d/10-bws.conf
+[Service]
+EnvironmentFile=%h/.config/openclaw/bws.env
+```
+then `systemctl --user daemon-reload`.
+
+### 4. Define the provider and the references (run as `openclaw`)
+```bash
+openclaw config set secrets.providers.bws \
+  --provider-source exec \
+  --provider-command /home/openclaw/.config/openclaw/openclaw-bws-secret-provider.sh \
+  --provider-pass-env BWS_ACCESS_TOKEN --provider-pass-env BWS_PROJECT_ID \
+  --provider-json-only
+
+openclaw config set models.providers.openrouter.apiKey \
+  --ref-source exec --ref-provider bws --ref-id OPENROUTER_API_KEY
+
+openclaw config set channels.telegram.botToken \
+  --ref-source exec --ref-provider bws --ref-id TELEGRAM_BOT_TOKEN
+```
+`openrouter` is a **built-in** provider (models `mode: merge` keeps built-ins and refreshes
+SecretRef-managed apiKeys), so you don't need a `baseUrl`.
+
+### 5. Pick a model + enable the channel
+```bash
+openclaw config set agents.defaults.model "openrouter/google/gemini-3.5-flash"
+openclaw config set channels.telegram.enabled true --strict-json
+openclaw config validate
+```
+
+### 6. Restart + verify
+```bash
+systemctl --user restart openclaw-gateway.service
+# logs should show: "…model configured, enabled automatically" / "[gateway] ready" / "[telegram] starting provider (@bot)"
+journalctl --user -u openclaw-gateway.service --since "1 min ago" --no-pager | grep -iE 'model configured|ready|telegram|degraded|SecretProvider'
+```
+
+## Gotchas
+
+- **`Exec provider "bws" exited with code 1` right after `config set`** is expected from the
+  *old* gateway process — it has no `EnvironmentFile`-loaded BWS vars until you **restart**.
+  A config reload ≠ reloading the systemd EnvironmentFile. After `systemctl restart` it clears.
+- **Validate with exec:** `openclaw config set … --dry-run --allow-exec` will actually run the
+  provider (needs the BWS vars in your shell — `source bws.env` first).
+- `bws` output may be ANSI-colored; the shipped wrapper strips it before `jq`.
+- Resolve by **key name** (the wrapper does) so rotating a secret's UUID doesn't break refs.


### PR DESCRIPTION
## Summary
This branch carries the Phase 3 docs/structural work **plus** deploy hardening and a complete BWS secrets recipe surfaced by a real end-to-end deploy onto a fresh Ubuntu 24.04 droplet with a modern Ansible (core 2.19) controller.

**Deploy hardening (Ansible core 2.19 compatibility):**
- `ansible/bootstrap.yml`: POSIX `>` redirect in the apt-lock wait (the bash-only `&>` runs under `/bin/sh`=dash and loops forever); create the admin user's `.ssh` dir so the authorized_keys fallback (copy module) doesn't fail on a missing parent.
- `ansible/openclaw-team.yml`: rewrite the Deploy task to an explicit `cmd:` with the vision conditional in a single-line env var — the old inline Jinja `{% if %}` + nested-quote bash idiom failed 2.19's argument splitter; also exclude `ansible/secrets`, `*.vault.yml`, and `.claude` from the host rsync.

**Docs + reusable artifacts:**
- `docs/deployment-notes.md` — fresh-droplet runbook + gotchas: the separate `openclaw` gateway-install step no playbook runs, the 2.19 fixes, and the `-e key="value with spaces"` extra-vars truncation trap.
- `docs/secrets-bws.md` + `ansible/files/openclaw-bws-secret-provider.sh` — complete resolve-at-start BWS secret-reference recipe and a shipped resolver (replaces the prior "not shipped yet" sketch in `advanced.md`).
- Cross-links added from `CLAUDE.md`, `docs/advanced.md`, `ansible/README.md`.

**Also bundled (pre-existing commits already on this branch):**
- `Phase 3: secrets cross-links, service docs, structural assert`
- `Make VISION.md seed-once in the deployer (match documented contract)`

## Test plan
- [x] `ansible-playbook --syntax-check` passes for `bootstrap.yml` + `openclaw-team.yml`
- [x] Resolver passes `bash -n`
- [x] Validated end-to-end on a fresh Ubuntu 24.04 droplet: bootstrap → gateway install → team deploy → OpenRouter + Telegram secrets resolved from BWS at gateway startup, **no keys written to `~/.openclaw/.env`**
- [ ] Reviewer: confirm the two bundled Phase 3 commits are intended to merge in this PR (split out if not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)